### PR TITLE
BUILD SCRIPT ONLY: Do not conditionally build the app server further

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -299,14 +299,10 @@ function build_as {
 
   WILDFLY_VERSION_FROM_JBOSS_AS=`awk '/wildfly-parent/ { while(!/<version>/) {getline;} print; }' ${WILDFLY_CLONED_REPO}/pom.xml | cut -d \< -f 2|cut -d \> -f 2`
 
-  if [ ! -d  ${WILDFLY_CLONED_REPO}/dist/target/wildfly-${WILDFLY_VERSION_FROM_JBOSS_AS} ]; then
-
-    # building WildFly
-    export MAVEN_OPTS="-XX:MaxMetaspaceSize=512m $MAVEN_OPTS"
-    JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxMetaspaceSize=512m $JAVA_OPTS" ./build.sh clean install -B -DskipTests -Dts.smoke=false $IPV6_OPTS -Dversion.org.jboss.narayana.lra=${LRA_CURRENT_VERSION} "$@"
-    [ $? -eq 0 ] || fatal "AS build failed"
-
-  fi
+  # building WildFly
+  export MAVEN_OPTS="-XX:MaxMetaspaceSize=512m $MAVEN_OPTS"
+  JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxMetaspaceSize=512m $JAVA_OPTS" ./build.sh clean install -B -DskipTests -Dts.smoke=false $IPV6_OPTS -Dversion.org.jboss.narayana.lra=${LRA_CURRENT_VERSION} "$@"
+  [ $? -eq 0 ] || fatal "AS build failed"
 
   echo "AS version is ${WILDFLY_VERSION_FROM_JBOSS_AS}"
   JBOSS_HOME=${WILDFLY_CLONED_REPO}/dist/target/wildfly-${WILDFLY_VERSION_FROM_JBOSS_AS}


### PR DESCRIPTION
Having conditionally building the app server within the build_as function doesn't seem to be a necessary facility so if developer asks for the build of the app server even if it has been built before, do try to build it

NO_TEST