### PR TITLE
BUILD SCRIPT ONLY: Allow the crash module to import into IDE nicely

### DIFF
--- a/test/crash/pom.xml
+++ b/test/crash/pom.xml
@@ -12,7 +12,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>crash-test</artifactId>
+  <artifactId>lra-crash-test</artifactId>
   <name>LRA crash tests</name>
   <description>LRA integration tests using unmanaged containers to simulate crash scenarios</description>
 


### PR DESCRIPTION
!JACOCO

Without this change, I do not find the module importing nice to the IDE I use. The artifact is not deployed to nexus so should be for developers.