### PR TITLE
BUILD SCRIPT ONLY: Debug arguments for the different servers

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -198,7 +198,7 @@
     <profile>
       <id>codeCoverage</id>
       <properties>
-        <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
+        <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
                         -Dorg.jboss.byteman.transform.all
                         -javaagent:${project.build.directory}/lib/byteman.jar=listener:true</jvm.args.byteman>
     <jvm.args.debug></jvm.args.debug>
+    <lra.coordinator.debug.params></lra.coordinator.debug.params>
 
     <!-- IP stack configs. -->
     <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
@@ -84,7 +85,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
+    <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.modular}</server.jvm.args>
     <skipITs>true</skipITs>
     <skipMavenDeployMojo>false</skipMavenDeployMojo>
     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>

--- a/test/basic/src/test/resources/arquillian-wildfly.xml
+++ b/test/basic/src/test/resources/arquillian-wildfly.xml
@@ -11,7 +11,7 @@
     <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="suite" default="true">
         <configuration>
             <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
-            <property name="javaVmArguments">${server.jvm.args} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
+            <property name="javaVmArguments">${server.jvm.args} ${lra.coordinator.debug.params} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
             <property name="managementAddress">${test.application.host}</property>
             <property name="managementPort">10090</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/test/crash/src/test/resources/arquillian-wildfly.xml
+++ b/test/crash/src/test/resources/arquillian-wildfly.xml
@@ -11,7 +11,7 @@
     <group qualifier="${arquillian.group.qualifier}" default="true">
         <container qualifier="${arquillian.lra.coordinator.container.qualifier}" mode="manual">
             <configuration>
-                <property name="javaVmArguments">${server.jvm.args} -DObjectStoreEnvironmentBean.objectStoreDir=${project.build.directory}/wfly_lra_objectstore -DObjectStoreEnvironmentBean.communicationStore.objectStoreDir=${project.build.directory}/wfly_lra_objectstore</property>
+                <property name="javaVmArguments">${server.jvm.args} ${lra.coordinator.debug.params} -DObjectStoreEnvironmentBean.objectStoreDir=${project.build.directory}/wfly_lra_objectstore -DObjectStoreEnvironmentBean.communicationStore.objectStoreDir=${project.build.directory}/wfly_lra_objectstore</property>
                 <property name="managementAddress">${test.application.host}</property> <!-- default management port is 9990 -->
                 <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
                 <property name="serverConfig">${lra.coordinator.xml.filename}</property>
@@ -21,7 +21,7 @@
         <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="manual" default="true">
             <configuration>
                 <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
-                <property name="javaVmArguments">${server.jvm.args} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} ${jvm.args.debug} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
                 <property name="managementAddress">${test.application.host}</property>
                 <property name="managementPort">10090</property>
                 <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -69,6 +69,8 @@
         <configuration>
           <redirectTestOutputToFile>${test.logs.to.file}</redirectTestOutputToFile>
           <systemPropertyVariables combine="merge">
+            <jvm.args.debug>${jvm.args.debug}</jvm.args.debug>
+            <lra.coordinator.debug.params>${lra.coordinator.debug.params}</lra.coordinator.debug.params>
             <!-- failsafe test startup logging configuration-->
             <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
             <!-- host and port where to find the test application -->
@@ -336,7 +338,7 @@
     <profile>
       <id>codeCoverage</id>
       <properties>
-        <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
+        <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
       </properties>
     </profile>
     <profile>

--- a/test/tck/src/test/resources/arquillian-wildfly.xml
+++ b/test/tck/src/test/resources/arquillian-wildfly.xml
@@ -11,7 +11,7 @@
     <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="suite" default="true">
         <configuration>
             <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
-            <property name="javaVmArguments">${server.jvm.args} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100 -Dlra.tck.timeout.factor=${lra.tck.timeout.factor}</property>
+            <property name="javaVmArguments">${server.jvm.args} ${jvm.args.debug} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100 -Dlra.tck.timeout.factor=${lra.tck.timeout.factor}</property>
             <property name="managementAddress">${test.application.host}</property>
             <property name="managementPort">10090</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>


### PR DESCRIPTION
NO_TEST

This should help to make it easier to debug LRA coordinator test server and LRA participant test server on Arquillian.

The key part to watch for should be jvm.args.debug vs lra.coordinator.debug.params for the two server types (I used the existing property names, they are matched as I would like maybe jvm.args.debug would become lra.participant.debug.params and that might be clearer then)