### PR TITLE
JBTM-3966 fix LRA crash tests

### DIFF
--- a/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -319,17 +319,18 @@ public class LongRunningAction extends BasicAction {
                     }
 
                     if (status == LRAStatus.Active) {
-                        status = LRAStatus.Cancelling; // transition from Active to Cancelling
+                        status = LRAStatus.Cancelling;
+                        scheduler.schedule(this::abortLRA, 1, TimeUnit.MILLISECONDS);
                     }
                 } else {
                     if (LRALogger.logger.isDebugEnabled()) {
                         LRALogger.logger.debugf("Restarting time for LRA '%s'", id);
                     }
-                }
 
-                // remark setTimeLimit can call deactivate (under failure conditions)
-                // and since we are in the middle of a restore we don't want call save
-                setTimeLimit(ttl, false);
+                    // remark setTimeLimit can call deactivate (under failure conditions)
+                    // and since we are in the middle of a restore we don't want call save
+                    setTimeLimit(ttl, false);
+                }
             }
 
             return true;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3966


scheduler for cancellation of short LRAs:  https://github.com/jbosstm/lra/blob/main/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java#L1105

the scheduler sets the status to cancelled when lists are empty: https://github.com/jbosstm/lra/blob/main/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java#L1189

when a short LRA times out while the server is down that method is not called, and when it is restored the status goes to cancelling: https://github.com/jbosstm/lra/blob/main/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java#L322

Eventually the LRA transaction is removed from the objsectStore (during the recovering cycle)  and the participants are notified that has been cancelled.

Please note that if a LRA is in cancelling status but all the lists are empty it is considered finished: https://github.com/jbosstm/lra/blob/main/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java#L427-L441