### PR TITLE
[JBTM-3985] Adding the waitForCallbacks implementation

### DIFF
--- a/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
+++ b/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
@@ -6,6 +6,9 @@
 package io.narayana.lra.arquillian.spi;
 
 import io.narayana.lra.LRAConstants;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
 import org.jboss.logging.Logger;
 
@@ -19,10 +22,26 @@ import static io.narayana.lra.LRAConstants.RECOVERY_COORDINATOR_PATH_NAME;
 
 public class NarayanaLRARecovery implements LRARecoveryService {
     private static final Logger log = Logger.getLogger(NarayanaLRARecovery.class);
+    private static final long WAIT_CALLBACK_TIMEOUT = initWaitForCallbackTimeout();
+    private static final String WAIT_CALLBACK_TIMEOUT_PROPERTY = "lra.tck.callback.timeout";
 
+    /*
+     * Wait for the participant to return the callback. This method does not
+     * guarantee callbacks to finish. The Participant status is not immediately
+     * reflected to the LRA status, but only after a recovery scan which executes an
+     * enlistment. The waiting time can be configurable by
+     * LRAConstants.WAIT_CALLBACK_TIMEOUT property.
+     */
     @Override
     public void waitForCallbacks(URI lraId) {
-        // no action needed
+        log.info("Wait for the callback to be returned by the CompletionStage");
+        log.info("waitForCallbacks for: " + lraId.toASCIIString());
+        try {
+            Thread.sleep(WAIT_CALLBACK_TIMEOUT);
+        }
+        catch (InterruptedException e) {
+            log.error("waitForCallbacks interrupted by " + e.getMessage());
+        }
     }
 
     @Override
@@ -59,5 +78,20 @@ public class NarayanaLRARecovery implements LRARecoveryService {
             // intended LRA didn't recover
             return !json.contains(lraId.toASCIIString());
         }
+    }
+
+    private static Integer initWaitForCallbackTimeout() {
+        Config config = ConfigProvider.getConfig();
+        int defaultValue = 1000;
+        if (config != null) {
+            try {
+                return config.getOptionalValue(WAIT_CALLBACK_TIMEOUT_PROPERTY, Integer.class).orElse(defaultValue);
+            }
+            catch (IllegalArgumentException e) {
+                log.error("property " + WAIT_CALLBACK_TIMEOUT_PROPERTY + " not set correctly, using the default value: "
+                        + defaultValue);
+            }
+        }
+        return defaultValue;
     }
 }

--- a/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
+++ b/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
@@ -34,8 +34,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
      */
     @Override
     public void waitForCallbacks(URI lraId) {
-        log.info("Wait for the callback to be returned by the CompletionStage");
-        log.info("waitForCallbacks for: " + lraId.toASCIIString());
+        log.trace("waitForCallbacks for: " + lraId.toASCIIString());
         try {
             Thread.sleep(WAIT_CALLBACK_TIMEOUT);
         }
@@ -46,7 +45,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
 
     @Override
     public boolean waitForEndPhaseReplay(URI lraId) {
-        log.info("waitForEndPhaseReplay for: " + lraId.toASCIIString());
+        log.trace("waitForEndPhaseReplay for: " + lraId.toASCIIString());
         if (!recoverLRAs(lraId)) {
             // first recovery scan probably collided with periodic recovery which started
             // before the test execution so try once more


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3985

In the implementation we added a timeout to wait for callbacks because the Participant status is not immediately reflected to the LRA status, but only after a recovery scan which executes an enlistment. 
