### PR TITLE
JBTM-3989 Configurable timeout obtaining lock for enlist participant

### DIFF
--- a/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -65,6 +65,16 @@ public final class LRAConstants {
     public static final long PARTICIPANT_TIMEOUT = 2;
     public static final String ALLOW_PARTICIPANT_DATA = "lra.participant.data";
 
+    /**
+     * Number of milliseconds for the coordinator to hold a lock for enlisting participants. Defaults to 500.
+     */
+    public static final String ENLIST_PARTICIPANT_LOCK_TIMEOUT = "lra.participant.lock.timeout";
+
+    /**
+     * Numbers of times a client participant tries to enlist with the coordinator before giving up. Defaults to 3.
+     */
+    public static final String ENLIST_PARTICIPANT_CLIENT_MAX_RETRY = "lra.participant.client.max.retry";
+
     private static final Pattern UID_REGEXP_EXTRACT_MATCHER = Pattern.compile(".*/([^/?]+).*");
 
     private LRAConstants() {


### PR DESCRIPTION
Suggestion for implementing a solution to https://issues.redhat.com/browse/JBTM-3989

Specifically for obtaining a lock when enlisting participants, I introduced a variant with a timeout. It default to 500ms, which can be configured to any other setting (including 0, to effectively disable timeout and fail right away).

Only enlisting participants uses the new try lock method, since the other usages indeed seem to only need trying the lock and not necessarily waiting for it.

