### PR TITLE
Remove not needed active-mq dependency

### DIFF
--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -73,21 +73,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!--
-        remark: the next dependency, namely org.apache.activemq:artemis-journal, is also depended upon
-        by org.jboss.narayana.arjunacore:arjuna but that uses <scope>provided</scope>
-      -->
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>artemis-journal</artifactId>
-      <version>${version.org.apache.activemq}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
 
     <!-- Needed for WildflyLRACoordinatorDeployment class -->
     <version.microprofile.lra>2.0.1</version.microprofile.lra>
-    <version.org.apache.activemq>2.38.0</version.org.apache.activemq>
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
     <version.org.eclipse.microprofile.openapi>3.1</version.org.eclipse.microprofile.openapi>
 
@@ -211,11 +210,6 @@
       </dependency>
 
       <!-- undertow with RestEasy -->
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-client</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-client</artifactId>
@@ -959,15 +953,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <configuration>
-              <reportPlugins>
-                <plugin>
-                  <groupId>com.github.spotbugs</groupId>
-                  <artifactId>spotbugs-maven-plugin</artifactId>
-                  <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
-                </plugin>
-              </reportPlugins>
-            </configuration>
             <dependencies>
               <dependency>
                 <groupId>org.apache.maven.doxia</groupId>
@@ -998,6 +983,15 @@
           </plugin>
         </plugins>
       </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
+            <version>${version.com.github.spotbugs.spotbugs-maven-plugin}</version>
+          </plugin>
+        </plugins>
+      </reporting>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
- removing no needed active-mq dependency
- removing duplicated resteasy-client dependency
- fixing the reporting plugin configuration