### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/jacoco-profile.yml
+++ b/.github/workflows/jacoco-profile.yml
@@ -15,15 +15,14 @@ jobs:
         java-version: [ 21 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: jbosstm/lra
-          ref: main
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         name: Set up JDK ${{ matrix.java-version }}
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: temurin
+          cache: maven
 
       - name: JACOCO test
         run: |

--- a/.github/workflows/lra-profile.yml
+++ b/.github/workflows/lra-profile.yml
@@ -15,15 +15,14 @@ jobs:
         java-version: [ 17, 21 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: jbosstm/lra
-          ref: main
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         name: Set up JDK ${{ matrix.java-version }}
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: temurin
+          cache: maven
 
       - name: LRA test
         run: |


### PR DESCRIPTION
This PR depends on https://github.com/jbosstm/lra/pull/46

Updating actions to use version 4
Updating setup-java step to use distribution 'temurin' and maven cache

In this PR I am removing also the 'with' section of the checkout step, which was leading to the main branch's testing instead of the PR branch's.

