### PR TITLE
JBTM-3994  Fix for long running action to set right end status for a failure to compensate with at least 2 participant

### DIFF
--- a/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
@@ -13,6 +13,8 @@ import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiat
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.eclipse.microprofile.lra.annotation.LRAStatus.FailedToCancel;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import io.narayana.lra.LRAConstants;
 import io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator;
@@ -80,13 +82,12 @@ public class FailedLRAMultiplePartipantsIT extends TestBase {
 
         String status = getLraEndStatus(LRA_PARTICIPANT_PATH, LRA_END_STATUS, lraId);
 
+        assertEquals("FailedToCancel", status);
+
         log.infov("Received status {0} (should be FailedToCancel)", status);
 
         if (!validateStateAndRemove(lraId, FailedToCancel)) {
-            log.info("lra not in failed list (should have been)");
-
-            // TODO: fail test after fix
-            // fail("lra not in failed list");
+            fail("lra not in failed list (should have been)");
         }
     }
 

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
@@ -1,0 +1,202 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import static io.narayana.lra.LRAConstants.RECOVERY_COORDINATOR_PATH_NAME;
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.BASE_URL_PARAM;
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.LRA_END_STATUS;
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.LRA_PARTICIPANT_PATH;
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.TRANSACTIONAL_START_PATH;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static org.eclipse.microprofile.lra.annotation.LRAStatus.FailedToCancel;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator;
+import io.narayana.lra.arquillian.resource.LRAMultipleParticipant2;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.core.Response;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * There is a spec requirement to report failed LRAs but the spec only requires that a failure message is reported
+ * (not how it is reported). Failure records are vital pieces of data needed to aid failure tracking and analysis.
+ * <p>
+ * The Narayana implementation allows failed LRAs to be directly queried. The following tests validate that the
+ * correct failure records are kept until explicitly removed.
+ */
+public class FailedLRAMultiplePartipantsIT extends TestBase {
+    private static final Logger log = Logger.getLogger(FailedLRAMultiplePartipantsIT.class);
+
+    @ArquillianResource
+    public URL baseURL;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Override
+    public void before() {
+        super.before();
+        log.info("Running test " + testName.getMethodName());
+    }
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(FailedLRAMultiplePartipantsIT.class.getSimpleName(),
+                LRAMultipleParticipant1Initiator.class, LRAMultipleParticipant2.class);
+    }
+
+    static String getRecoveryUrl(URI lraId) {
+        return LRAConstants.getLRACoordinatorUrl(lraId) + "/" + RECOVERY_COORDINATOR_PATH_NAME;
+    }
+
+    /**
+     * test that a failure record is created when a participant (with status reporting) fails to compensate
+     */
+    @Test
+    public void testWithStatusCompensateFailed() {
+        URI lraId = invokeInTransaction(LRA_PARTICIPANT_PATH, TRANSACTIONAL_START_PATH, 500);
+
+        lrasToAfterFinish.add(lraId);
+
+        String status = getLraEndStatus(LRA_PARTICIPANT_PATH, LRA_END_STATUS, lraId);
+
+        log.infov("Received status {0} (should be FailedToCancel)", status);
+
+        if (!validateStateAndRemove(lraId, FailedToCancel)) {
+            log.info("lra not in failed list (should have been)");
+
+            // TODO: fail test after fix
+            // fail("lra not in failed list");
+        }
+    }
+
+    private String getLraEndStatus(String resourcePrefix, String resourcePath, URI lraId) {
+        for (int i = 0; i < 10; i++) {
+            try (Response response = client.target(baseURL.toURI())
+                    .path(resourcePrefix)
+                    .path(resourcePath)
+                    .queryParam(LRA_HTTP_CONTEXT_HEADER, lraId)
+                    .request()
+                    .get()) {
+
+                Assert.assertTrue("Expecting a non empty body in response from " + resourcePrefix + "/" + resourcePath,
+                        response.hasEntity());
+
+                if (response.getStatus() != 202) {
+                    return response.readEntity(String.class);
+                }
+
+                log.infov("AfterLRA not yet called. Waiting {0}/10", i);
+                Thread.sleep(1000);
+
+            } catch (URISyntaxException e) {
+                throw new IllegalStateException("response cannot be converted to URI: " + e.getMessage());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private URI invokeInTransaction(String resourcePrefix, String resourcePath, int expectedStatus) {
+        try (Response response = client.target(baseURL.toURI())
+                .path(resourcePrefix)
+                .path(resourcePath)
+                .queryParam(BASE_URL_PARAM, baseURL)
+                .request()
+                .get()) {
+
+            Assert.assertTrue("Expecting a non empty body in response from " + resourcePrefix + "/" + resourcePath,
+                    response.hasEntity());
+
+            String entity = response.readEntity(String.class);
+
+            Assert.assertEquals(
+                    "response from " + resourcePrefix + "/" + resourcePath + " was " + entity,
+                    expectedStatus, response.getStatus());
+
+            return new URI(entity);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("response cannot be converted to URI: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Validate whether a given LRA is in a particular state.
+     * Also validate that the corresponding record is removed.
+     *
+     * @param lra the LRA whose state is to be validated
+     * @param state the state that the target LRA should be in
+     * @return true if the LRA is in the target state and that its log was successfully removed
+     */
+    private boolean validateStateAndRemove(URI lra, LRAStatus state) {
+        for (JsonValue failedLRA : getFailedRecords(lra)) {
+
+            String lraId = failedLRA.asJsonObject().getString("lraId")
+                    .replaceAll("\\\\", "");
+
+            if (lraId.contains(lra.toASCIIString())) {
+                if (failedLRA.asJsonObject().getString("status").equals(state.name())) {
+
+                    // Remove the failed LRA
+                    Assert.assertEquals("Could not remove log",
+                            NO_CONTENT.getStatusCode(),
+                            removeFailedLRA(lra));
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // Look up LRAs that are in a failed state (ie FailedToCancel or FailedToClose)
+    private JsonArray getFailedRecords(URI lra) {
+        String recoveryUrl = getRecoveryUrl(lra);
+
+        try (Response response = client.target(recoveryUrl).path("failed").request().get()) {
+            Assert.assertTrue("Missing response body when querying for failed LRAs", response.hasEntity());
+            String failedLRAs = response.readEntity(String.class);
+
+            return Json.createReader(new StringReader(failedLRAs)).readArray();
+        }
+    }
+
+    // Ask the recovery coordinator to delete its log for an LRA
+    private int removeFailedLRA(URI lra) {
+        String recoveryUrl = getRecoveryUrl(lra);
+        String txId = URLEncoder.encode(lra.toASCIIString(), StandardCharsets.UTF_8);
+
+        return removeFailedLRA(recoveryUrl, txId);
+    }
+
+    // Ask the recovery coordinator to delete its log for an LRA
+    private int removeFailedLRA(String recoveryUrl, String lra) {
+        try (Response response = client.target(recoveryUrl).path(lra).request().delete()) {
+            return response.getStatus();
+        }
+    }
+}

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/FailedLRAMultiplePartipantsIT.java
@@ -7,7 +7,6 @@ package io.narayana.lra.arquillian;
 
 import static io.narayana.lra.LRAConstants.RECOVERY_COORDINATOR_PATH_NAME;
 import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.BASE_URL_PARAM;
-import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.LRA_END_STATUS;
 import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.LRA_PARTICIPANT_PATH;
 import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.TRANSACTIONAL_START_PATH;
 import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
@@ -80,11 +79,23 @@ public class FailedLRAMultiplePartipantsIT extends TestBase {
 
         lrasToAfterFinish.add(lraId);
 
-        String status = getLraEndStatus(LRA_PARTICIPANT_PATH, LRA_END_STATUS, lraId);
+        String status1 = getLraEndStatus(
+                LRAMultipleParticipant1Initiator.LRA_PARTICIPANT_PATH,
+                LRAMultipleParticipant1Initiator.LRA_END_STATUS,
+                lraId);
 
-        assertEquals("FailedToCancel", status);
+        assertEquals("FailedToCancel", status1);
 
-        log.infov("Received status {0} (should be FailedToCancel)", status);
+        log.infov("Received status 1 {0} (should be FailedToCancel)", status1);
+
+        String status2 = getLraEndStatus(
+                LRAMultipleParticipant2.LRA_PARTICIPANT_PATH,
+                LRAMultipleParticipant2.LRA_END_STATUS,
+                lraId);
+
+        assertEquals("FailedToCancel", status2);
+
+        log.infov("Received status 2 {0} (should be FailedToCancel)", status2);
 
         if (!validateStateAndRemove(lraId, FailedToCancel)) {
             fail("lra not in failed list (should have been)");

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAMultipleParticipant1Initiator.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAMultipleParticipant1Initiator.java
@@ -1,0 +1,141 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ParticipantStatus.Active;
+import static org.eclipse.microprofile.lra.annotation.ParticipantStatus.Compensated;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.REQUIRES_NEW;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Forget;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.Status;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAMultipleParticipant1Initiator {
+    public static final String LRA_PARTICIPANT_PATH = "participant1-initiator";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+    public static final String BASE_URL_PARAM = "base-url";
+
+    private static final Logger log = Logger.getLogger(LRAMultipleParticipant1Initiator.class);
+
+    private static final AtomicInteger forgetCount = new AtomicInteger(0);
+    private static final AtomicInteger compensateCount = new AtomicInteger(0);
+    private static final Map<URI, LRAStatus> status = new ConcurrentHashMap<>();
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = REQUIRES_NEW, timeLimit = 200)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, @QueryParam(BASE_URL_PARAM) URL baseUrl)
+            throws URISyntaxException {
+        log.infov("\033[0;1mStarting LRA with ID {0}", lraId);
+        log.infov("\033[0;1mReceived base URL from client: {0}", baseUrl);
+
+        WebTarget target = ClientBuilder.newClient()
+                .target(baseUrl.toURI())
+                .path(LRAMultipleParticipant2.LRA_PARTICIPANT_PATH)
+                .path(LRAMultipleParticipant2.TRANSACTIONAL_START_PATH);
+
+        log.infov("\033[0;1mCalling participant 2 at {0}", target.getUri());
+
+        Response response = target
+                .request()
+                .header(LRA_HTTP_CONTEXT_HEADER, lraId)
+                .get();
+
+        log.infov("\033[0;1mReceived response from participant 2: {0}", response.readEntity(String.class));
+
+        log.infov("\033[0;1mReturning status 500 to purposely fail the LRA!");
+        return Response.status(500).entity(lraId.toASCIIString()).build();
+    }
+
+    @PUT
+    @Path("compensate")
+    @Compensate
+    public Response compensate(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m@Compensate called for {0}. Returning OK.", lraId);
+
+        compensateCount.incrementAndGet();
+
+        return Response.ok().build();
+    }
+
+    @DELETE
+    @Path("forget")
+    @Forget
+    public Response forget(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m@Forget called for {0}. Returning OK.", lraId);
+
+        forgetCount.incrementAndGet();
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("status")
+    @Status
+    public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m@Status called for {0}.", lraId);
+
+        if (compensateCount.get() == 1) {
+            log.infov("\033[0;1mReturning OK with body Compensated");
+            return Response.ok(Compensated.name()).build();
+        }
+
+        log.infov("\033[0;1mReturning OK with body Active");
+        return Response.ok(Active.name()).build();
+    }
+
+    @PUT
+    @Path("after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m@AfterLRA called for {0} with LRAStatus {1}", lraId, lraStatus);
+
+        status.put(lraId, lraStatus);
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path(LRA_END_STATUS)
+    public Response getLraStatus(@QueryParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1mgetLraStatus() called for {0}.", lraId);
+
+        if (!status.containsKey(lraId)) {
+            log.infov("\033[0;1mAfterLRA not yet called. Returning 202");
+            return Response.status(202).entity(lraId.toASCIIString() + "AfterLRA not yet called").build();
+        }
+
+        log.infov("\033[0;1mAfterLRA called. Returning 200 with {0} ", status.get(lraId).name());
+        return Response.ok(status.get(lraId).name()).build();
+    }
+
+}

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAMultipleParticipant2.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAMultipleParticipant2.java
@@ -1,0 +1,101 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant2.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ParticipantStatus.Active;
+import static org.eclipse.microprofile.lra.annotation.ParticipantStatus.FailedToCompensate;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Forget;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.Status;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAMultipleParticipant2 {
+    public static final String LRA_PARTICIPANT_PATH = "participant2";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+
+    private static final Logger log = Logger.getLogger(LRAMultipleParticipant2.class);
+
+    private static final AtomicInteger forgetCount = new AtomicInteger(0);
+    private static final AtomicInteger compensateCount = new AtomicInteger(0);
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = MANDATORY, end = false, timeLimit = 100)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[34mJoining LRA with ID {0}", lraId);
+
+        return Response.ok(lraId.toASCIIString()).build();
+    }
+
+    @PUT
+    @Path("compensate")
+    @Compensate
+    public Response compensate(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) throws NotFoundException {
+        log.infov("\033[0;1m\u001B[34m@Compensate called for {0}. Returning 500 to purposely fail the compensate!", lraId);
+
+        compensateCount.incrementAndGet();
+
+        return Response.status(500).entity(FailedToCompensate.name()).build();
+    }
+
+    @DELETE
+    @Path("forget")
+    @Forget
+    public Response forget(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m@Forget called for {0}. Returning OK.", lraId);
+
+        forgetCount.incrementAndGet();
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("status")
+    @Status
+    public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[34m@Status called for {0}.", lraId);
+
+        System.out.println(
+                "xxxxxxxxxxx LRAMultipleParticipant2 Status called" +
+                        " compensateCount" + compensateCount);
+
+        if (compensateCount.get() == 1) {
+            return Response.ok(FailedToCompensate.name()).build();
+        }
+
+        return Response.ok(Active.name()).build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[34m@AfterLRA called for {0} with LRAStatus {1}", lraId, lraStatus);
+
+        return Response.ok().build();
+    }
+
+}


### PR DESCRIPTION
(the test doesn't fail now, but just prints the outcome)

For the context of this test, see https://issues.redhat.com/projects/JBTM/issues/JBTM-3994


