### PR TITLE
restore crash tests and disable deploy.lra.coordinator in build script

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -86,7 +86,7 @@ function init_test_options {
     [ $CODE_COVERAGE ] || CODE_COVERAGE=0
     [ x"$CODE_COVERAGE_ARGS" != "x" ] || CODE_COVERAGE_ARGS=""
     [ $ARQ_PROF ] || ARQ_PROF=arq	# IPv4 arquillian profile
-    [ $USE_LATEST_COORDINATOR] || USE_LATEST_COORDINATOR=" -Pdeploy.lra.coordinator"	# use the built coordinator
+    [ $USE_LATEST_COORDINATOR] || USE_LATEST_COORDINATOR="" # use -Pdeploy.lra.coordinator for the built coordinator
     [ $ENABLE_LRA_TRACE_LOGS ] || ENABLE_LRA_TRACE_LOGS=" -Dtest.logs.to.file=true -Dtrace.lra.coordinator"
 
     if ! get_pull_xargs "$PULL_DESCRIPTION_BODY" $PROFILE; then # see if the PR description overrides the profile

--- a/test/crash/src/test/java/io/narayana/lra/arquillian/Deployer.java
+++ b/test/crash/src/test/java/io/narayana/lra/arquillian/Deployer.java
@@ -21,6 +21,9 @@ public class Deployer {
 
         return ShrinkWrap.create(WebArchive.class, appName + ".war")
 
+                .addPackages(true,
+                        "io.smallrye.stork",
+                        "io.smallrye.mutiny")
                 // Additional Services to deploy
                 .addClasses(classes)
                 // Support libraries


### PR DESCRIPTION
This PR is needed to fix the failing jacoco profile and re-enable crash-tests

Disabling the lra-deploy-coordinator is needed in order to test the crash test, in fact that profile exclude the integration test of the crash-test module: https://github.com/jbosstm/lra/pull/48/files#diff-63dc8be7e50c9d6685f98818cd088168fd9b2ead857e9e7dbe5f7d4fd682d16dR373-R375
