### PR TITLE
Update resteasy to 6.2.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
 
     <version.io.smallrye.smallrye-config>3.2.0</version.io.smallrye.smallrye-config>
     <version.io.smallrye.smallrye-stork>2.7.0</version.io.smallrye.smallrye-stork>
-    <version.io.undertow>2.3.18.Final</version.io.undertow>
     <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
     <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
     <version.jakarta.json-api>2.1.1</version.jakarta.json-api>
@@ -154,7 +153,7 @@
     <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logging.jboss-logging-processor>2.2.1.Final</version.org.jboss.logging.jboss-logging-processor>
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
-    <version.org.jboss.resteasy>6.2.10.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>6.2.12.Final</version.org.jboss.resteasy>
     <version.org.jboss.shrinkwrap.resolvers>3.3.2</version.org.jboss.shrinkwrap.resolvers>
     <version.org.jboss.weld>5.0.1.Final</version.org.jboss.weld>
     <version.org.sonatype.plugins.nxrm3.plugin>1.0.7</version.org.sonatype.plugins.nxrm3.plugin>
@@ -242,16 +241,6 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-undertow</artifactId>
         <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-core</artifactId>
-        <version>${version.io.undertow}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-servlet</artifactId>
-        <version>${version.io.undertow}</version>
       </dependency>
       <!-- end undertow with RestEasy -->
 


### PR DESCRIPTION
Update resteasy to 6.2.12.Final. undertow-core and undertow-servlet  2.3.18 are included in resteasy-undertow 6.2.12.Final