### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'issue/bug'
+labels: issue/bug, needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -2,7 +2,7 @@
 name: Custom issue template
 about: Describe this issue template's purpose here.
 title: ''
-labels: ''
+labels: needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'issue/feature-request'
+labels: issue/feature-request, needs-triage
 assignees: ''
 
 ---


### PR DESCRIPTION
Add needs-triage label by default

The setting is not available for the 'Blank issue' option