### PR TITLE
Fix NarayanaLRAClient coordinator URL priority first by constructor then by property

### DIFF
--- a/arquillian-extension/src/main/java/io/narayana/lra/arquillian/appender/MpLraTckAuxiliaryArchiveAppender.java
+++ b/arquillian-extension/src/main/java/io/narayana/lra/arquillian/appender/MpLraTckAuxiliaryArchiveAppender.java
@@ -81,9 +81,6 @@ public class MpLraTckAuxiliaryArchiveAppender implements AuxiliaryArchiveAppende
                         "beans.xml")
                 // for WildFly we need dependencies to be part of the deployment's class path
                 .addAsManifestResource(new StringAsset(ManifestMF), "MANIFEST.MF");
-        // add MP config properties file
-        archive.addAsResource(new StringAsset("lra.coordinator.urls=http://localhost:50000, http://localhost:50001"),
-                "META-INF/microprofile-config.properties");
         archive.addPackages(true, io.narayana.lra.filter.ClientLRARequestFilter.class.getPackage())
                 .addAsResource(new StringAsset("org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder"),
                         "META-INF/services/jakarta.ws.rs.client.ClientBuilder");

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -77,5 +77,15 @@
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>
+    <!-- TODO remove this dependency once the NarayanaLRAClient(String, String, int, String) constructor is removed -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/client/src/test/java/io/narayana/lra/client/NarayanaLRAClientTest.java
+++ b/client/src/test/java/io/narayana/lra/client/NarayanaLRAClientTest.java
@@ -1,0 +1,45 @@
+package io.narayana.lra.client;
+
+import static org.junit.Assert.assertEquals;
+
+import io.narayana.lra.client.internal.NarayanaLRAClient;
+import java.net.URI;
+import org.junit.Test;
+
+public class NarayanaLRAClientTest {
+
+    @Test
+    public void testConstructors() {
+        try (NarayanaLRAClient client = new NarayanaLRAClient()) {
+            assertEquals("http://localhost:8080/lra-coordinator", client.getCoordinatorUrl());
+        }
+
+        try (NarayanaLRAClient client = new NarayanaLRAClient("https", "test-url", 16663, "random-path")) {
+            assertEquals("https://test-url:16663/random-path", client.getCoordinatorUrl());
+        }
+
+        try (NarayanaLRAClient client = new NarayanaLRAClient(URI.create("http://test-url/random-path"))) {
+            assertEquals("http://test-url/random-path", client.getCoordinatorUrl());
+        }
+
+        try (NarayanaLRAClient client = new NarayanaLRAClient("http://test-url")) {
+            assertEquals("http://test-url", client.getCoordinatorUrl());
+        }
+    }
+
+    @Test
+    public void testCoordinatorURLOverrideWithConfig() {
+        String original = System.getProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY);
+        System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, "http://test-url:16663/random-path");
+
+        try (NarayanaLRAClient client = new NarayanaLRAClient()) {
+            assertEquals("http://test-url:16663/random-path", client.getCoordinatorUrl());
+        }
+
+        if (original != null) {
+            System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, original);
+        }
+
+        System.out.println(System.getProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY));
+    }
+}

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/InvalidLBTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/InvalidLBTest.java
@@ -24,10 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
-import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -73,11 +71,6 @@ public class InvalidLBTest extends LRATestBase {
         }
     }
 
-    @BeforeClass
-    public static void start() {
-        System.setProperty("lra.coordinator.url", TestPortProvider.generateURL('/' + COORDINATOR_PATH_NAME));
-    }
-
     @Before
     public void before() {
         clearObjectStore(testName);
@@ -100,7 +93,7 @@ public class InvalidLBTest extends LRATestBase {
                     host, ports[i], COORDINATOR_PATH_NAME, i + 1 < ports.length ? "," : ""));
         }
 
-        System.setProperty(NarayanaLRAClient.COORDINATOR_URLS_KEY, sb.toString());
+        System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, sb.toString());
 
         if (lb_method != null)
             System.setProperty(NarayanaLRAClient.COORDINATOR_LB_METHOD_KEY, lb_method);

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LBTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LBTest.java
@@ -7,7 +7,6 @@ package io.narayana.lra.coordinator.domain.model;
 import static io.narayana.lra.LRAConstants.COORDINATOR_PATH_NAME;
 import static io.narayana.lra.client.internal.NarayanaLRAClient.LB_METHOD_ROUND_ROBIN;
 import static io.narayana.lra.client.internal.NarayanaLRAClient.LB_METHOD_STICKY;
-import static io.narayana.lra.client.internal.NarayanaLRAClient.LRA_COORDINATOR_URL_KEY;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -32,10 +31,8 @@ import java.util.HashSet;
 import java.util.Set;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
-import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -82,11 +79,6 @@ public class LBTest extends LRATestBase {
         }
     }
 
-    @BeforeClass
-    public static void start() {
-        System.setProperty(LRA_COORDINATOR_URL_KEY, TestPortProvider.generateURL('/' + COORDINATOR_PATH_NAME));
-    }
-
     @Before
     public void before() {
         clearObjectStore(testName);
@@ -109,7 +101,7 @@ public class LBTest extends LRATestBase {
                     host, ports[i], COORDINATOR_PATH_NAME, i + 1 < ports.length ? "," : ""));
         }
 
-        System.setProperty(NarayanaLRAClient.COORDINATOR_URLS_KEY, sb.toString());
+        System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, sb.toString());
 
         if (lb_method != null) {
             System.setProperty(NarayanaLRAClient.COORDINATOR_LB_METHOD_KEY, lb_method);

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -74,7 +74,6 @@ import org.jboss.resteasy.test.TestPortProvider;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -121,11 +120,6 @@ public class LRATest extends LRATestBase {
         }
     }
 
-    @BeforeClass
-    public static void start() {
-        System.setProperty("lra.coordinator.url", TestPortProvider.generateURL('/' + COORDINATOR_PATH_NAME));
-    }
-
     @Before
     public void before() {
         LRALogger.logger.debugf("Starting test %s", testName);
@@ -149,7 +143,7 @@ public class LRATest extends LRATestBase {
                     host, ports[i], COORDINATOR_PATH_NAME, i + 1 < ports.length ? "," : ""));
         }
 
-        System.setProperty(NarayanaLRAClient.COORDINATOR_URLS_KEY, sb.toString());
+        System.setProperty(NarayanaLRAClient.LRA_COORDINATOR_URL_KEY, sb.toString());
 
         lraClient = new NarayanaLRAClient();
 


### PR DESCRIPTION
Note that this is my take into how it should look like but I am willing to adjust it if agreed differently. This PR proposes:

- First look into whatever user passes as constructor argument
- If nothing, then look into "lra.coordinator.url" property 

See that I dropped "lra.coordinator.urls" (note the s at the end) because this is the same config also in the original code and there is no point in having two keys for the same thing as it might confuse users. I believe this is the best solution but feel free to suggest otherwise.

Fixes #175