### PR TITLE
TEST CHANGE ONLY: option to automatically download WildFly

### DIFF
--- a/test/README.adoc
+++ b/test/README.adoc
@@ -44,6 +44,12 @@ The **WildFly** runtime is used through the 'arq' profile. Two instances of Wild
    with the current project changes).
  * The second instance is started using Arquillian to deploy the LRA participant
    under test. Moreover, the testing class is hosted on separated JVM.
+ 
+A WildFly instance can be provided to the tests in 3 ways:
+ * Via the `JBOSS_HOME` environment variable pointing to an existing WildFly installation.
+ * By using the `-Pdownload` profile; this downloads and unpacks the zip distribution from Maven central and points the tests to it.
+ * By using the `-Pprovision` profile; this provisions a WildFly Galleon instance and points the tests to it.
+   
 
 === Running tests with WildFly
 
@@ -51,11 +57,10 @@ To start all integration tests, testing with the coordinator that was build by t
 
 [source,sh]
 ----
-export JBOSS_HOME=<path-to-wildfly-distribution-directory>
-mvn clean verify -Parq
+mvn clean verify -Parq,provision
 
 # single test in one module
-mvn clean verify -Parq -pl :lra-test-basic -Dit.test=FailedLRAIT
+mvn clean verify -Parq,provision -pl :lra-test-basic -Dit.test=FailedLRAIT
 ----
 
 To start all integration tests, testing with the build-in coordinator of WildFly:
@@ -76,5 +81,8 @@ mvn clean verify -Parq,coordinator.wildfly.subsystem -pl :lra-test-basic -Dit.te
 
 | `-Ddebug`
 | The WildFly waits at port `8787` for debugger to connect.
+
+| `-Dwildfly.version`
+| When using the download or provision profiles; the version of WildFly to download resp. provision
 
 |===

--- a/test/basic/src/test/resources/arquillian-wildfly.xml
+++ b/test/basic/src/test/resources/arquillian-wildfly.xml
@@ -11,6 +11,7 @@
     <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="suite" default="true">
         <configuration>
             <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
+            <property name="jbossHome">${wildfly.home}</property>
             <property name="javaVmArguments">${server.jvm.args} ${lra.coordinator.debug.params} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
             <property name="managementAddress">${test.application.host}</property>
             <property name="managementPort">10090</property>

--- a/test/crash/pom.xml
+++ b/test/crash/pom.xml
@@ -16,6 +16,10 @@
   <name>LRA crash tests</name>
   <description>LRA integration tests using unmanaged containers to simulate crash scenarios</description>
 
+  <properties>
+    <skip.wildfly.plugin>true</skip.wildfly.plugin>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jboss.narayana.lra</groupId>

--- a/test/crash/src/test/resources/arquillian-wildfly.xml
+++ b/test/crash/src/test/resources/arquillian-wildfly.xml
@@ -11,6 +11,7 @@
     <group qualifier="${arquillian.group.qualifier}" default="true">
         <container qualifier="${arquillian.lra.coordinator.container.qualifier}" mode="manual">
             <configuration>
+                <property name="jbossHome">${wildfly.home}</property>
                 <property name="javaVmArguments">${server.jvm.args} ${lra.coordinator.debug.params} -DObjectStoreEnvironmentBean.objectStoreDir=${project.build.directory}/wfly_lra_objectstore -DObjectStoreEnvironmentBean.communicationStore.objectStoreDir=${project.build.directory}/wfly_lra_objectstore</property>
                 <property name="managementAddress">${test.application.host}</property> <!-- default management port is 9990 -->
                 <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
@@ -21,6 +22,7 @@
         <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="manual" default="true">
             <configuration>
                 <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
+                <property name="jbossHome">${wildfly.home}</property>
                 <property name="javaVmArguments">${server.jvm.args} ${jvm.args.debug} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
                 <property name="managementAddress">${test.application.host}</property>
                 <property name="managementPort">10090</property>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,7 +24,6 @@
   </modules>
 
   <properties>
-
     <lra.coordinator.debug.params></lra.coordinator.debug.params>
     <!-- defined within -Ddebug.coordinator/-Pdebug.lra.coordinator -->
     <lra.coordinator.debug.port>8788</lra.coordinator.debug.port>
@@ -34,13 +33,16 @@
     <!-- currently only defines where to search for the coordinator, it does not change where the coordinator is started -->
     <lra.coordinator.host>localhost</lra.coordinator.host>
     <lra.coordinator.port>8080</lra.coordinator.port>
+
     <!-- the property used by NarayanaLRAClient when passed into the container as the JVM parameter -->
     <lra.coordinator.url>http://${lra.coordinator.host}:${lra.coordinator.port}/lra-coordinator</lra.coordinator.url>
+
     <!-- for test executions where coordinator is started as a separate JVM (e.g. for Quarkus) and the test application
              is deployed at the different JVM; these properties define where the test JVM application is started -->
     <test.application.host>localhost</test.application.host>
     <test.application.port>8180</test.application.port>
     <version.resteasy-client>${version.org.jboss.resteasy}</version.resteasy-client>
+    <wildfly.home>${env.JBOSS_HOME}</wildfly.home>
   </properties>
 
   <dependencies>
@@ -82,19 +84,25 @@
           <systemPropertyVariables combine="merge">
             <jvm.args.debug>${jvm.args.debug}</jvm.args.debug>
             <lra.coordinator.debug.params></lra.coordinator.debug.params>
+
             <!-- failsafe test startup logging configuration-->
             <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
+
             <!-- host and port where to find the test application -->
             <test.application.host>${test.application.host}</test.application.host>
             <test.application.port>${test.application.port}</test.application.port>
             <lra.tck.suite.host>${test.application.host}</lra.tck.suite.host>
+
             <!-- not necessary for test/basic but for TCK it's necessary -->
             <lra.tck.suite.port>${test.application.port}</lra.tck.suite.port>
             <lra.coordinator.url>${lra.coordinator.url}</lra.coordinator.url>
+
             <!-- passing to Arquillian as configured at arquillian*.xml and used for app server start-up (e.g. sets up debug) -->
             <server.jvm.args>${server.jvm.args}</server.jvm.args>
+
             <!-- used at AppServerCoordinatorDeploymentObserver -->
             <project.version>${project.version}</project.version>
+
             <!-- used in arquillian*.xml descriptor to place test run related data -->
             <project.build.directory>${project.build.directory}</project.build.directory>
           </systemPropertyVariables>
@@ -127,7 +135,7 @@
         <lra.coordinator.war.name>lra-coordinator.war</lra.coordinator.war.name>
 
         <!-- The following filename is used for starting the WildFly instance that hosts the LRA coordinator; this file is a copy of the
-             standalone.xml file provided in WildFly (${env.JBOSS_HOME}/standalone/configuration/standalone.xml). Please, see the plugins
+             standalone.xml file provided in WildFly (${wildfly.home}/standalone/configuration/standalone.xml). Please, see the plugins
              section of this profile (specifically, maven-antrun-plugin) for further info -->
         <lra.coordinator.xml.filename>lra-coordinator.xml</lra.coordinator.xml.filename>
 
@@ -138,12 +146,12 @@
         <lra.participant.deployment.qualifier>lra-participant</lra.participant.deployment.qualifier>
 
         <!-- The following filename is used for starting the WildFly instance that hosts the LRA participant; this file is a copy of the
-             standalone.xml file provided in WildFly (${env.JBOSS_HOME}/standalone/configuration/standalone.xml). Please, see the plugins
+             standalone.xml file provided in WildFly (${wildfly.home}/standalone/configuration/standalone.xml). Please, see the plugins
              section of this profile (specifically, maven-antrun-plugin) for further info -->
         <lra.participant.xml.filename>lra-participant.xml</lra.participant.xml.filename>
 
         <server.jvm.object.store.arg>-DObjectStoreEnvironmentBean.objectStoreDir=${lra.coordinator.object.store.path}</server.jvm.object.store.arg>
-        <skip.wildfly.plugin>true</skip.wildfly.plugin>
+        <skip.wildfly.plugin>false</skip.wildfly.plugin>
 
         <!-- where the WFLY test application will be started at (the coordinator is war deployed for the same app server at the same port) -->
         <test.application.port>8080</test.application.port>
@@ -167,7 +175,6 @@
 
       <build>
         <plugins>
-
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
@@ -181,10 +188,10 @@
                 <configuration>
                   <rules>
                     <requireProperty>
-                      <property>env.JBOSS_HOME</property>
-                      <message>You need to define JBOSS_HOME environmental variable!</message>
+                      <property>wildfly.home</property>
+                      <message>You need to define JBOSS_HOME environmental variable or wildfly.home -D property!</message>
                       <regex>[^ ]*</regex>
-                      <regexMessage>You must set JBOSS_HOME environmental variable containing at least one non-space character.</regexMessage>
+                      <regexMessage>You must set JBOSS_HOME environmental variable or wildfly.home -D property containing at least one non-space character.</regexMessage>
                     </requireProperty>
                   </rules>
                   <fail>true</fail>
@@ -209,14 +216,13 @@
                     <delete dir="../../ObjectStore" failonerror="false"></delete>
 
                     <!-- We overwrite the config files as the config.to.replace can be different in different modules and without overwrite being the case, then the file will not be written over -->
-                    <copy file="${env.JBOSS_HOME}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${env.JBOSS_HOME}/standalone/configuration/${lra.coordinator.xml.filename}"></copy>
-                    <copy file="${env.JBOSS_HOME}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${env.JBOSS_HOME}/standalone/configuration/${lra.participant.xml.filename}"></copy>
+                    <copy file="${wildfly.home}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}"></copy>
+                    <copy file="${wildfly.home}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${wildfly.home}/standalone/configuration/${lra.participant.xml.filename}"></copy>
 
                     <!-- Activate the build-in LRA coordinator in WildFly, unless we're deploying the one we just build. -->
-                    <replace file="${env.JBOSS_HOME}/standalone/configuration/${lra.coordinator.xml.filename}" token="org.wildfly.extension.microprofile.jwt-smallrye" value="org.wildfly.extension.microprofile.jwt-smallrye&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.openapi-smallrye"></replace>
-                    <replace file="${env.JBOSS_HOME}/standalone/configuration/${lra.coordinator.xml.filename}" token="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0" value="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-lra-coordinator:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-openapi-smallrye:1.0"></replace>
-                    <replace file="${env.JBOSS_HOME}/standalone/configuration/${lra.coordinator.xml.filename}" token="object-store path=&quot;tx-object-store" value="object-store path=&quot;wfly_lra_objectstore"></replace>
-
+                    <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="org.wildfly.extension.microprofile.jwt-smallrye" value="org.wildfly.extension.microprofile.jwt-smallrye&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.openapi-smallrye"></replace>
+                    <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0" value="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-lra-coordinator:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-openapi-smallrye:1.0"></replace>
+                    <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="object-store path=&quot;tx-object-store" value="object-store path=&quot;wfly_lra_objectstore"></replace>
                   </target>
                 </configuration>
               </execution>
@@ -249,7 +255,7 @@
                 <phase>pre-integration-test</phase>
                 <configuration>
                   <!-- used by start -->
-                  <jbossHome>${env.JBOSS_HOME}</jbossHome>
+                  <jbossHome>${wildfly.home}</jbossHome>
                   <serverConfig>${lra.coordinator.xml.filename}</serverConfig>
                   <javaOpts>${server.jvm.args} ${server.jvm.object.store.arg} ${lra.coordinator.debug.params}</javaOpts>
                 </configuration>
@@ -301,29 +307,126 @@
               <skipITs>false</skipITs>
               <reportsDirectory>${project.build.directory}/failsafe-reports-arq</reportsDirectory>
               <summaryFile>${project.build.directory}/failsafe-reports-arq/failsafe-summary.xml</summaryFile>
-              <systemProperties>
+              <systemPropertyVariables>
                 <arquillian.xml>arquillian-wildfly.xml</arquillian.xml>
+
                 <!-- qualifier used to identify the Wildfly cluster -->
                 <arquillian.group.qualifier>wildfly-cluster</arquillian.group.qualifier>
+
                 <!-- qualifier used to identify the Wildfly container where lra-coordinator will be deployed-->
                 <arquillian.lra.coordinator.container.qualifier>${lra.coordinator.container.qualifier}</arquillian.lra.coordinator.container.qualifier>
+
                 <!-- qualifier used to identify the Wildfly container where lra-participant will be deployed-->
                 <arquillian.lra.participant.container.qualifier>${lra.participant.container.qualifier}</arquillian.lra.participant.container.qualifier>
+
                 <!-- qualifier used to identify the lra-coordinator deployment-->
                 <arquillian.lra.coordinator.deployment.qualifier>${lra.coordinator.deployment.qualifier}</arquillian.lra.coordinator.deployment.qualifier>
+
                 <!-- qualifier used to identify the lra-participant deployment-->
                 <arquillian.lra.participant.deployment.qualifier>${lra.participant.deployment.qualifier}</arquillian.lra.participant.deployment.qualifier>
+
                 <!-- sharing with Arquillian the names of the XML standalone configurations for Wildfly instances -->
                 <lra.coordinator.xml.filename>${lra.coordinator.xml.filename}</lra.coordinator.xml.filename>
                 <lra.participant.xml.filename>${lra.participant.xml.filename}</lra.participant.xml.filename>
+
                 <!-- used to resolve the resteasy-client version -->
                 <version.resteasy-client>${version.resteasy-client}</version.resteasy-client>
+
                 <!-- used to resolve eclipse microprofile versions -->
                 <version.microprofile.lra>${version.microprofile.lra}</version.microprofile.lra>
-              </systemProperties>
+
+                <wildfly.home>${wildfly.home}</wildfly.home>
+              </systemPropertyVariables>
+
+              <environmentVariables>
+                <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
+              </environmentVariables>
             </configuration>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
 
+    <!-- 
+      Provision a WildFly instance using Galleon and set it up to be used for the tests
+    -->
+    <profile>
+      <id>provision</id>
+
+      <properties>
+        <wildfly.home>${user.dir}/target/wildfly</wildfly.home>
+        <wildfly.version>38.0.1.Final</wildfly.version>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly-maven-plugin}</version>
+            <executions>
+              <execution>
+                <id>provision-wildfly</id>
+                <goals>
+                  <goal>provision</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <inherited>false</inherited>
+                <configuration>
+                  <provisioningDir>${wildfly.home}</provisioningDir>
+                  <feature-packs>
+                    <feature-pack>
+                      <location>wildfly@maven(org.jboss.universe:community-universe)#${wildfly.version}</location>
+                    </feature-pack>
+                  </feature-packs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- 
+      Download the zip distribution of WildFly and set it up to be used for the tests
+    -->
+    <profile>
+      <id>download</id>
+
+      <properties>
+        <wildfly.home>${wildfly.root}/wildfly-${wildfly.version}</wildfly.home>
+        <wildfly.root>${user.dir}/target/wildfly</wildfly.root>
+        <wildfly.version>38.0.1.Final</wildfly.version>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.8.1</version>
+            <executions>
+              <execution>
+                <id>unpack-wildfly</id>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <markersDirectory>${wildfly.home}/dependency-maven-plugin-markers</markersDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${wildfly.version}</version>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${wildfly.root}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -405,7 +508,7 @@
                 <phase>pre-integration-test</phase>
                 <configuration>
                   <skip>${skip.wildfly.plugin}</skip>
-                  <basedir>${env.JBOSS_HOME}/bin/</basedir>
+                  <basedir>${wildfly.home}/bin/</basedir>
                   <executable>./jboss-cli.sh</executable>
                   <arguments>
                     <argument>--file=${wildfly.trace.logging.cli.script}</argument>


### PR DESCRIPTION
Adds profiles that allows one to instead of installing WildFly on the system and setting an environment variable, have the test code download or provision a WildFly instance.

In prepaparion for #126, but very useful by itself too.