### PR TITLE
Lraid managed executor

### DIFF
--- a/arquillian-extension/src/main/java/io/narayana/lra/arquillian/appender/MpLraTckAuxiliaryArchiveAppender.java
+++ b/arquillian-extension/src/main/java/io/narayana/lra/arquillian/appender/MpLraTckAuxiliaryArchiveAppender.java
@@ -76,14 +76,21 @@ public class MpLraTckAuxiliaryArchiveAppender implements AuxiliaryArchiveAppende
                         "io.smallrye.mutiny.helpers")
                 // registration of LRACDIExtension as Weld extension to be booted-up
                 .addAsResource("META-INF/services/jakarta.enterprise.inject.spi.Extension")
+
                 // explicitly define to work with annotated beans
                 .addAsManifestResource(new StringAsset("<beans version=\"1.1\" bean-discovery-mode=\"annotated\"></beans>"),
                         "beans.xml")
+
                 // for WildFly we need dependencies to be part of the deployment's class path
                 .addAsManifestResource(new StringAsset(ManifestMF), "MANIFEST.MF");
-        archive.addPackages(true, io.narayana.lra.filter.ClientLRARequestFilter.class.getPackage())
+
+        archive.addPackages(true,
+                io.narayana.lra.filter.ClientLRARequestFilter.class.getPackage(),
+                io.narayana.lra.context.ClientLRAContextProviderEE.class.getPackage())
                 .addAsResource(new StringAsset("org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder"),
-                        "META-INF/services/jakarta.ws.rs.client.ClientBuilder");
+                        "META-INF/services/jakarta.ws.rs.client.ClientBuilder")
+                .addAsResource(new StringAsset("io.narayana.lra.context.ClientLRAContextProviderEE"),
+                        "META-INF/services/jakarta.enterprise.concurrent.spi.ThreadContextProvider");
 
         // adding TCK required SPI implementation
         archive.addClass(NarayanaLRARecovery.class);

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -36,6 +36,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.context-propagation</groupId>
+      <artifactId>microprofile-context-propagation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise.concurrent</groupId>
+      <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>

--- a/jaxrs/src/main/java/io/narayana/lra/context/ClientLRAContextProviderEE.java
+++ b/jaxrs/src/main/java/io/narayana/lra/context/ClientLRAContextProviderEE.java
@@ -1,0 +1,66 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.context;
+
+import io.narayana.lra.Current;
+import io.narayana.lra.logging.LRALogger;
+import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+import jakarta.enterprise.concurrent.spi.ThreadContextSnapshot;
+import jakarta.enterprise.inject.Vetoed;
+import java.net.URI;
+import java.util.Map;
+
+@Vetoed // never a CDI bean
+public class ClientLRAContextProviderEE implements ThreadContextProvider {
+
+    private static final ThreadContextSnapshot NOOP_SNAPSHOT = () -> () -> {
+    };
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        URI lraId = Current.peek();
+        if (lraId == null) {
+            return NOOP_SNAPSHOT;
+        }
+
+        long originThreadId = Thread.currentThread().getId();
+
+        return () -> {
+            long executionThreadId = Thread.currentThread().getId();
+
+            if (originThreadId != executionThreadId) {
+                LRALogger.logger.debugf("Pushing %s from thread %d to %d", lraId, originThreadId, executionThreadId);
+
+                // Executed in new Thread
+                Current.push(lraId);
+            }
+
+            return () -> {
+                long restorerThreadId = Thread.currentThread().getId();
+
+                if (originThreadId != restorerThreadId && executionThreadId == restorerThreadId) {
+                    // Executed in new Thread
+                    URI oldLra = Current.pop();
+
+                    LRALogger.logger.debugf("Popping %s obtained from thread %d in %d", oldLra, originThreadId,
+                            restorerThreadId);
+                }
+            };
+
+        };
+    }
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return NOOP_SNAPSHOT;
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return "Lra-client";
+    }
+
+}

--- a/jaxrs/src/main/java/io/narayana/lra/context/ClientLRAContextProviderMP.java
+++ b/jaxrs/src/main/java/io/narayana/lra/context/ClientLRAContextProviderMP.java
@@ -1,0 +1,66 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.context;
+
+import io.narayana.lra.Current;
+import io.narayana.lra.logging.LRALogger;
+import jakarta.enterprise.inject.Vetoed;
+import java.net.URI;
+import java.util.Map;
+import org.eclipse.microprofile.context.spi.ThreadContextProvider;
+import org.eclipse.microprofile.context.spi.ThreadContextSnapshot;
+
+@Vetoed // never a CDI bean
+public class ClientLRAContextProviderMP implements ThreadContextProvider {
+
+    private static final ThreadContextSnapshot NOOP_SNAPSHOT = () -> () -> {
+    };
+
+    @Override
+    public ThreadContextSnapshot currentContext(Map<String, String> props) {
+        URI lraId = Current.peek();
+        if (lraId == null) {
+            return NOOP_SNAPSHOT;
+        }
+
+        long originThreadId = Thread.currentThread().getId();
+
+        return () -> {
+            long executionThreadId = Thread.currentThread().getId();
+
+            if (originThreadId != executionThreadId) {
+                LRALogger.logger.debugf("Pushing %s from thread %d to %d", lraId, originThreadId, executionThreadId);
+
+                // Executed in new Thread
+                Current.push(lraId);
+            }
+
+            return () -> {
+                long restorerThreadId = Thread.currentThread().getId();
+
+                if (originThreadId != restorerThreadId && executionThreadId == restorerThreadId) {
+                    // Executed in new Thread
+                    URI oldLra = Current.pop();
+
+                    LRALogger.logger.debugf("Popping %s obtained from thread %d in %d", oldLra, originThreadId,
+                            restorerThreadId);
+                }
+            };
+
+        };
+    }
+
+    @Override
+    public ThreadContextSnapshot clearedContext(Map<String, String> props) {
+        return NOOP_SNAPSHOT;
+    }
+
+    @Override
+    public String getThreadContextType() {
+        return "Lra-client";
+    }
+
+}

--- a/jaxrs/src/main/resources/META-INF/services/jakarta.enterprise.concurrent.spi.ThreadContextProvider
+++ b/jaxrs/src/main/resources/META-INF/services/jakarta.enterprise.concurrent.spi.ThreadContextProvider
@@ -1,0 +1,1 @@
+io.narayana.lra.context.ClientLRAContextProviderEE

--- a/jaxrs/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
+++ b/jaxrs/src/main/resources/META-INF/services/org.eclipse.microprofile.context.spi.ThreadContextProvider
@@ -1,0 +1,1 @@
+io.narayana.lra.context.ClientLRAContextProviderMP

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
 
     <version.io.smallrye.smallrye-config>3.15.0</version.io.smallrye.smallrye-config>
     <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
+    <version.jakarta.concurrent>3.1.0</version.jakarta.concurrent>
     <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
     <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
     <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
@@ -137,6 +138,7 @@
     <version.maven.jar-plugin>3.2.0</version.maven.jar-plugin>
     <version.maven.shade-plugin>3.2.4</version.maven.shade-plugin>
     <version.maven.surefire-plugin>3.1.2</version.maven.surefire-plugin>
+    <version.microprofile-context-propagation-api>1.3</version.microprofile-context-propagation-api>
     <version.microprofile.config-api>3.1</version.microprofile.config-api>
     <version.microprofile.fault-tolerance>4.1.2</version.microprofile.fault-tolerance>
 
@@ -158,6 +160,7 @@
     <version.org.sonatype.plugins.nxrm3.plugin>1.0.13</version.org.sonatype.plugins.nxrm3.plugin>
     <version.org.wildfly.arquillian>5.1.0.Final</version.org.wildfly.arquillian>
     <version.parsson>1.1.7</version.parsson>
+    <version.quarkus>3.30.5</version.quarkus>
     <version.smallrye-converter-api>2.7.0</version.smallrye-converter-api>
     <version.sortpom>4.0.0</version.sortpom>
     <version.undertow.core>2.3.20.Final</version.undertow.core>
@@ -210,6 +213,12 @@
         <groupId>jakarta.enterprise</groupId>
         <artifactId>jakarta.enterprise.cdi-api</artifactId>
         <version>${version.jakarta.enterprise}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.enterprise.concurrent</groupId>
+        <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+        <version>${version.jakarta.concurrent}</version>
       </dependency>
 
       <!-- Ensure these are in the distribution -->
@@ -294,6 +303,11 @@
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
         <version>${version.microprofile.config-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.microprofile.context-propagation</groupId>
+        <artifactId>microprofile-context-propagation-api</artifactId>
+        <version>${version.microprofile-context-propagation-api}</version>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>

--- a/service-base/src/main/java/io/narayana/lra/Current.java
+++ b/service-base/src/main/java/io/narayana/lra/Current.java
@@ -40,21 +40,26 @@ public class Current {
 
     @SuppressWarnings("ConstantConditions")
     public static void addActiveLRACache(URI lraId) {
-        if (lraId != null && activeLRACache.containsKey(lraId)) {
-            activeLRACache.compute(lraId, (k, v) -> v + 1);
-        } else {
-            activeLRACache.put(lraId, 1);
+        if (lraId == null) {
+            return;
         }
+
+        activeLRACache.merge(lraId, 1, Integer::sum);
     }
 
     public static void removeActiveLRACache(URI lraId) {
-        if (lraId != null && activeLRACache.containsKey(lraId)) {
-            activeLRACache.compute(lraId, (k, v) -> v - 1);
-
-            if (activeLRACache.get(lraId) == 0) {
-                activeLRACache.remove(lraId);
-            }
+        if (lraId == null) {
+            return;
         }
+
+        activeLRACache.compute(lraId, (k, v) -> {
+            if (v == null) {
+                return null; // already absent; nothing to do
+            }
+
+            int next = v - 1;
+            return next <= 0 ? null : next; // remove at 0
+        });
     }
 
     private final Stack<URI> stack;

--- a/test/README.adoc
+++ b/test/README.adoc
@@ -86,3 +86,16 @@ mvn clean verify -Parq,coordinator.wildfly.subsystem -pl :lra-test-basic -Dit.te
 | When using the download or provision profiles; the version of WildFly to download resp. provision
 
 |===
+
+=== Running against WildFly build from source with updated LRA
+
+This project contains a script that uses a two-tiered checkout of WildFly and builds it with the LRA version from this repo. It then executes TCK tests directly against it, and then runs the tests from this repo against it.
+
+Invoke from the root of this repo using:
+
+[source,sh]
+----
+BASH_INTERPRETER=/bin/bash WORKSPACE=$PWD PROFILE=LRA ./scripts/hudson/narayana.sh
+----
+
+

--- a/test/basic/pom.xml
+++ b/test/basic/pom.xml
@@ -30,6 +30,15 @@
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.enterprise.concurrent</groupId>
+      <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.context-propagation</groupId>
+      <artifactId>microprofile-context-propagation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana.lra</groupId>
       <artifactId>lra-test-arquillian-extension</artifactId>
       <scope>test</scope>

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/LRAAsyncLRAIT.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/LRAAsyncLRAIT.java
@@ -1,0 +1,78 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import static io.narayana.lra.arquillian.resource.LRAMultipleParticipant1Initiator.BASE_URL_PARAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.narayana.lra.arquillian.resource.LRAAsyncParticipant1Initiator;
+import io.narayana.lra.arquillian.resource.LRAAsyncParticipant2Client1;
+import io.narayana.lra.arquillian.resource.LRAAsyncParticipant3Client2;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Optional;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class LRAAsyncLRAIT extends TestBase {
+
+    private static final Logger log = Logger.getLogger(LRAAsyncLRAIT.class);
+
+    @ArquillianResource
+    public URL baseURL;
+
+    public String testName;
+
+    @BeforeEach
+    public void before(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
+        log.info("Running test " + testName);
+    }
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(
+                LRAAsyncLRAIT.class.getSimpleName(),
+                LRAAsyncParticipant1Initiator.class,
+                LRAAsyncParticipant2Client1.class,
+                LRAAsyncParticipant3Client2.class);
+    }
+
+    @Test
+    public void testAfterLRACount() {
+        log.infov("\033[0;1mTest starting LRA test with URL {0}", baseURL);
+
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                    .path(LRAAsyncParticipant1Initiator.LRA_PARTICIPANT_PATH)
+                    .path(LRAAsyncParticipant1Initiator.TRANSACTIONAL_START_PATH)
+                    .queryParam(BASE_URL_PARAM, baseURL)
+                    .build())
+                    .request()
+                    .get()) {
+
+                assertEquals(200, response.getStatus());
+                assertTrue(response.hasEntity());
+            }
+        }
+    }
+
+    @BeforeEach
+    public void setup(TestInfo testInfo) {
+        Optional<Method> testMethod = testInfo.getTestMethod();
+        this.testName = testMethod.get().getName();
+    }
+}

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant1Initiator.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant1Initiator.java
@@ -1,0 +1,112 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static io.narayana.lra.arquillian.resource.LRAAsyncParticipant1Initiator.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.REQUIRES_NEW;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant1Initiator {
+    public static final String LRA_PARTICIPANT_PATH = "participant1-initiator";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+    public static final String BASE_URL_PARAM = "base-url";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant1Initiator.class);
+
+    private static final Map<URI, LRAStatus> status = new ConcurrentHashMap<>();
+
+    @Resource
+    ManagedExecutorService managedExecutorService;
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = REQUIRES_NEW, timeLimit = 200)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, @QueryParam(BASE_URL_PARAM) URL baseUrl)
+            throws URISyntaxException, InterruptedException, ExecutionException {
+        log.infov("\033[0;1m\u001B[33mStarting LRA with ID {0}" + managedExecutorService.toString(), lraId);
+        log.infov("\033[0;1m\u001B[33mReceived base URL from client: {0}", baseUrl);
+        log.infov("\033[0;1m\u001B[33mCoordinator URL: {0}", System.getProperty("lra.coordinator.url"));
+
+        Future<Response> futureResponse1 = managedExecutorService.submit(() -> {
+
+            WebTarget target = ClientBuilder.newClient()
+                    .target(baseUrl.toURI())
+                    .path(LRAAsyncParticipant2Client1.LRA_PARTICIPANT_PATH)
+                    .path(LRAAsyncParticipant2Client1.TRANSACTIONAL_START_PATH);
+
+            log.infov("\033[0;1m\u001B[33mCalling {0}", target.getUri());
+
+            return target.request().get();
+        });
+
+        Future<Response> futureResponse2 = managedExecutorService.submit(() -> {
+
+            WebTarget target = ClientBuilder.newClient()
+                    .target(baseUrl.toURI())
+                    .path(LRAAsyncParticipant3Client2.LRA_PARTICIPANT_PATH)
+                    .path(LRAAsyncParticipant3Client2.TRANSACTIONAL_START_PATH);
+
+            log.infov("\033[0;1m\u001B[33mCalling {0}", target.getUri());
+
+            return target.request().get();
+        });
+
+        String response1 = futureResponse1.get().readEntity(String.class);
+
+        log.infov("\033[0;1m\u001B[33mInitiator received response from client 1: {0}", response1);
+
+        String response2 = futureResponse2.get().readEntity(String.class);
+
+        log.infov("\033[0;1m\u001B[33mInitiator received response from client 2: {0}", response2);
+
+        if (!"Client1".equals(response1) || !"Client2".equals(response2)) {
+            log.infov("\033[0;1m\u001B[33m Unexpected responses: initiator returning status 500");
+            return Response.status(500).entity(lraId.toASCIIString()).build();
+        }
+
+        log.infov("\033[0;1m\u001B[33mExpected responses: initiator returning status 200");
+        return Response.status(200).entity(lraId.toASCIIString()).build();
+    }
+
+    @PUT
+    @Path("after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[33m@Initiator AfterLRA called for {0} with LRAStatus {1}", lraId, lraStatus);
+
+        status.put(lraId, lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant2Client1.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant2Client1.java
@@ -1,0 +1,53 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static io.narayana.lra.arquillian.resource.LRAAsyncParticipant2Client1.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant2Client1 {
+    public static final String LRA_PARTICIPANT_PATH = "participant2-client1";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant2Client1.class);
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = MANDATORY, end = false, timeLimit = 100)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[34mLRAAsyncParticipant2Client1 Joining LRA with ID {0}", lraId);
+
+        return Response.ok("Client1").build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[34m@LRAAsyncParticipant2Client1 AfterLRA called for {0} with LRAStatus {1}", lraId,
+                lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant3Client2.java
+++ b/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAAsyncParticipant3Client2.java
@@ -1,0 +1,53 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static io.narayana.lra.arquillian.resource.LRAAsyncParticipant3Client2.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant3Client2 {
+    public static final String LRA_PARTICIPANT_PATH = "participant3-client2";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant3Client2.class);
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = MANDATORY, end = false, timeLimit = 100)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[32mLRAAsyncParticipant3Client2 Joining LRA with ID {0}", lraId);
+
+        return Response.ok("Client2").build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[32m@LRAAsyncParticipant3Client2 AfterLRA called for {0} with LRAStatus {1}", lraId,
+                lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -37,6 +37,9 @@
     <!-- the property used by NarayanaLRAClient when passed into the container as the JVM parameter -->
     <lra.coordinator.url>http://${lra.coordinator.host}:${lra.coordinator.port}/lra-coordinator</lra.coordinator.url>
 
+    <lra.participant.debug.params></lra.participant.debug.params>
+    <lra.participant.debug.port>9088</lra.participant.debug.port>
+
     <!-- for test executions where coordinator is started as a separate JVM (e.g. for Quarkus) and the test application
              is deployed at the different JVM; these properties define where the test JVM application is started -->
     <test.application.host>localhost</test.application.host>
@@ -116,6 +119,7 @@
       <id>arq</id>
       <modules>
         <module>crash</module>
+        <module>quarkus</module>
       </modules>
       <properties>
         <config.to.replace>standalone.xml</config.to.replace>
@@ -206,6 +210,29 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
+                <id>replace-lra-jars</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                    <echo if:true="${wildfly.download}">wildfly.download=true, updating LRA jar versions in ${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml</echo>
+                    <echo unless:true="${wildfly.download}">wildfly.download is not true, skipping LRA module.xml update</echo>
+
+                    <!-- Update lra-client-* -->
+                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(lra-client-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
+
+                    <!-- Update lra-proxy-api-* -->
+                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(lra-proxy-api-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
+
+                    <!-- Update narayana-lra-* -->
+                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(narayana-lra-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
+                  </target>
+                </configuration>
+              </execution>
+
+              <execution>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -216,13 +243,17 @@
                     <delete dir="../../ObjectStore" failonerror="false"></delete>
 
                     <!-- We overwrite the config files as the config.to.replace can be different in different modules and without overwrite being the case, then the file will not be written over -->
+
+                    <!-- For the coordinator, create a new standalone.xml file where we add the extensions to activate the LRA coordinator -->
                     <copy file="${wildfly.home}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}"></copy>
-                    <copy file="${wildfly.home}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${wildfly.home}/standalone/configuration/${lra.participant.xml.filename}"></copy>
 
                     <!-- Activate the build-in LRA coordinator in WildFly, unless we're deploying the one we just build. -->
                     <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="org.wildfly.extension.microprofile.jwt-smallrye" value="org.wildfly.extension.microprofile.jwt-smallrye&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.lra-coordinator&quot;/&gt; &lt;extension module=&quot;org.wildfly.extension.microprofile.openapi-smallrye"></replace>
                     <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0" value="subsystem xmlns=&quot;urn:wildfly:microprofile-jwt-smallrye:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-lra-coordinator:1.0&quot;/&gt; &lt;subsystem xmlns=&quot;urn:wildfly:microprofile-openapi-smallrye:1.0"></replace>
                     <replace file="${wildfly.home}/standalone/configuration/${lra.coordinator.xml.filename}" token="object-store path=&quot;tx-object-store" value="object-store path=&quot;wfly_lra_objectstore"></replace>
+
+                    <!-- For the partipants, create a new standalone.xml as well, but don't change anything.  -->
+                    <copy file="${wildfly.home}/standalone/configuration/${config.to.replace}" overwrite="true" tofile="${wildfly.home}/standalone/configuration/${lra.participant.xml.filename}"></copy>
                   </target>
                 </configuration>
               </execution>
@@ -230,12 +261,18 @@
           </plugin>
 
           <!--
-            Wildfly is activated and configured through wildfly-maven-plugin instead
+            Start the WildFly instance for the LRA Coordinator
+            
+            Wildfly for the coordinator is activated and configured through wildfly-maven-plugin instead
             of using an Arquillian cluster. This design choice reflects the preference
-            to be consistent with the mechanism used to deploy lra-coordinator in
+            to be consistent with the mechanism used to deploy the lra-coordinator in
             Quarkus. Moreover, the Microprofile LRA TCK does not allow to use multiple
             Arquillian containers. As a consequence, lra-coordinator needs to be deployed
             separately.
+            
+            Note: The crash module disables this plug-in and uses an Arquillian group with two
+                  containers defined in the arquillian-wildfly.xml of that module.
+            
           -->
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
@@ -246,7 +283,7 @@
             </configuration>
 
             <executions>
-              <!-- Starts Wildfly -->
+              <!-- Starts Wildfly for the coordinator -->
               <execution>
                 <id>start</id>
                 <goals>
@@ -261,7 +298,12 @@
                 </configuration>
               </execution>
 
-              <!-- Deploys the coordinator to Wildfly -->
+              <!-- 
+                Deploys the coordinator war build by this project to Wildfly.
+                
+                Note that the coordinator.wildfly.subsystem profile disables
+                the deploy and undeploy of this coordinator war.
+               -->
               <execution>
                 <id>deploy-coordinator</id>
                 <goals>
@@ -276,7 +318,7 @@
                 </configuration>
               </execution>
 
-              <!-- Undeploys the coordinator from Wildfly -->
+              <!-- Undeploys the coordinator war from Wildfly -->
               <execution>
                 <id>undeploy-coordinator</id>
                 <goals>
@@ -288,7 +330,7 @@
                 </configuration>
               </execution>
 
-              <!-- Shutdowns Wildfly -->
+              <!-- Shutdowns Wildfly for the coordinator -->
               <execution>
                 <id>shutdown</id>
                 <goals>
@@ -299,6 +341,12 @@
             </executions>
           </plugin>
 
+          <!-- 
+              Starts the tests.
+              
+              As part of the tests, start up the 2nd WildFly instance for the participants.
+              
+          -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
@@ -310,24 +358,28 @@
               <systemPropertyVariables>
                 <arquillian.xml>arquillian-wildfly.xml</arquillian.xml>
 
-                <!-- qualifier used to identify the Wildfly cluster -->
+                <!-- qualifier used to identify the Wildfly cluster. Only used by crash module.  -->
                 <arquillian.group.qualifier>wildfly-cluster</arquillian.group.qualifier>
 
-                <!-- qualifier used to identify the Wildfly container where lra-coordinator will be deployed-->
+                <!-- qualifier used to identify the Wildfly container where lra-coordinator will be deployed. Only used by crash module.-->
                 <arquillian.lra.coordinator.container.qualifier>${lra.coordinator.container.qualifier}</arquillian.lra.coordinator.container.qualifier>
 
                 <!-- qualifier used to identify the Wildfly container where lra-participant will be deployed-->
                 <arquillian.lra.participant.container.qualifier>${lra.participant.container.qualifier}</arquillian.lra.participant.container.qualifier>
 
-                <!-- qualifier used to identify the lra-coordinator deployment-->
+                <!-- qualifier used to identify the lra-coordinator deployment. Only used by crash module. -->
                 <arquillian.lra.coordinator.deployment.qualifier>${lra.coordinator.deployment.qualifier}</arquillian.lra.coordinator.deployment.qualifier>
 
                 <!-- qualifier used to identify the lra-participant deployment-->
                 <arquillian.lra.participant.deployment.qualifier>${lra.participant.deployment.qualifier}</arquillian.lra.participant.deployment.qualifier>
 
-                <!-- sharing with Arquillian the names of the XML standalone configurations for Wildfly instances -->
+                <!-- XML standalone configurations for coordinator WildFly instance. Only used by crash module. -->
                 <lra.coordinator.xml.filename>${lra.coordinator.xml.filename}</lra.coordinator.xml.filename>
+
+                <!-- XML standalone configurations for participant WildFly instance. -->
                 <lra.participant.xml.filename>${lra.participant.xml.filename}</lra.participant.xml.filename>
+
+                <lra.participant.debug.params>${lra.participant.debug.params}</lra.participant.debug.params>
 
                 <!-- used to resolve the resteasy-client version -->
                 <version.resteasy-client>${version.resteasy-client}</version.resteasy-client>
@@ -394,6 +446,7 @@
       <id>download</id>
 
       <properties>
+        <wildfly.download>true</wildfly.download>
         <wildfly.home>${wildfly.root}/wildfly-${wildfly.version}</wildfly.home>
         <wildfly.root>${user.dir}/target/wildfly</wildfly.root>
         <wildfly.version>38.0.1.Final</wildfly.version>
@@ -425,6 +478,49 @@
                   </artifactItems>
                 </configuration>
               </execution>
+              <execution>
+                <id>update-narayana-lra</id>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <phase>process-test-classes</phase>
+                <configuration>
+                  <skip>${narayana.noupdate}</skip>
+                  <silent>false</silent>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jboss.narayana.lra</groupId>
+                      <artifactId>lra-client</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main</outputDirectory>
+                      <destFileName>lra-client-${project.version}.jar</destFileName>
+                    </artifactItem>
+
+                    <artifactItem>
+                      <groupId>org.jboss.narayana.lra</groupId>
+                      <artifactId>narayana-lra</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main</outputDirectory>
+                      <destFileName>narayana-lra-${project.version}.jar</destFileName>
+                    </artifactItem>
+
+                    <artifactItem>
+                      <groupId>org.jboss.narayana.lra</groupId>
+                      <artifactId>lra-proxy-api</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main</outputDirectory>
+                      <destFileName>lra-proxy-api-${project.version}.jar</destFileName>
+                    </artifactItem>
+
+                  </artifactItems>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>
@@ -440,6 +536,18 @@
       </activation>
       <properties>
         <lra.coordinator.debug.params>-Xrunjdwp:transport=dt_socket,address=${lra.coordinator.debug.port},server=y,suspend=y</lra.coordinator.debug.params>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>debug.lra.participant</id>
+      <activation>
+        <property>
+          <name>debug.participant</name>
+        </property>
+      </activation>
+      <properties>
+        <lra.participant.debug.params>-Xrunjdwp:transport=dt_socket,address=${lra.participant.debug.port},server=y,suspend=y</lra.participant.debug.params>
       </properties>
     </profile>
 

--- a/test/quarkus/context/README.adoc
+++ b/test/quarkus/context/README.adoc
@@ -1,0 +1,29 @@
+= Context propagation test for Quarkus
+
+WildFly and most other servers use Jakarta Concurrency for context propagation when doing async requests. This is covered by the io.narayana.lra.arquillian.LRAAsyncLRAIT test in the lra-test-basic module.
+
+This test can be executed using:
+
+```
+mvn clean install -Parq,download -pl :lra-test-basic -Dit.test=io.narayana.lra.arquillian.LRAAsyncLRAIT
+```
+
+However, Quarkus uses an older and non-maintained API called MicroProfile Context Propagation for this. MicroProfile Context Propagation moved to Jakarta Concurrency, so most other servers (specifically WildFly) have dropped support for this. Older WildFly versions do support it using a feature pack.
+
+LRA supports MicroProfile Context Propagation specifically for Quarkus, but therefore we also have to test with Quarkus. The test setup works as follows:
+
+The /build module builds a Quarkus uberjar containing the first participant in the LRA, which initiates the LRA. It asynchronously calls two other participants (client 1 and client 2), which both run on WildFly. Depending on the configuration options, the coordinator build by this project runs on a second WildFly instance.
+
+From this folder, using:
+
+```
+mvn clean install -Parq,download
+```
+
+The defaults are as follows:
+
+* WildFly 1 - HTTP port 8080 - started by Maven WildFly plugin. Runs coordinator war from module org.jboss.narayana.lra:lra-coordinator-war
+* Quarkus 1 - HTTP port 9080 - started by Maven Exec plugin. Runs initiator jar from module org.jboss.narayana.lra: lra-test-quarkus-context-build
+* WildFly 2 - HTTP port 8180 - started by Arquillian. Runs micro archive war created by test io.narayana.lra.arquillian.quarkus.LRAAsyncLRAIT
+
+ 

--- a/test/quarkus/context/build/pom.xml
+++ b/test/quarkus/context/build/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.lra</groupId>
+    <artifactId>lra-test-quarkus-context</artifactId>
+    <version>1.0.4.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lra-test-quarkus-context-build</artifactId>
+
+  <name>LRA tests: Quarkus Context Build</name>
+  <description>LRA test Building a jar for Quarkus to test context propagation</description>
+
+  <properties>
+    <!-- Encoding -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <quarkus.package.jar.add-runner-suffix>false</quarkus.package.jar.add-runner-suffix>
+
+    <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+    <quarkus.platform.version>${version.quarkus}</quarkus.platform.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <!-- Core DI -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+
+    <!-- LRA participant support -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-narayana-lra</artifactId>
+      <!-- Make it explicit that we replace narayana-lra -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.narayana.lra</groupId>
+          <artifactId>narayana-lra</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Make it explicit that we replace narayana-lra -->
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>narayana-lra</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Use RESTEasy Classic instead of Quarkus REST -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-client</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Quarkus build/dev/native -->
+      <plugin>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus.platform.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test/quarkus/context/build/src/main/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant1Initiator.java
+++ b/test/quarkus/context/build/src/main/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant1Initiator.java
@@ -1,0 +1,116 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+package io.narayana.lra.arquillian.quarkus.resource;
+
+import static io.narayana.lra.arquillian.quarkus.resource.LRAAsyncParticipant1Initiator.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.REQUIRES_NEW;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant1Initiator {
+
+    public static final String LRA_PARTICIPANT_PATH = "participant1-initiator";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+    public static final String BASE_URL_PARAM = "base-url";
+
+    public static final String LRA_PARTICIPANT2_PATH = "participant2-client1";
+    public static final String TRANSACTIONAL2_START_PATH = "start-work";
+
+    public static final String LRA_PARTICIPANT3_PATH = "participant3-client2";
+    public static final String TRANSACTIONAL3_START_PATH = "start-work";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant1Initiator.class);
+
+    private static final Map<URI, LRAStatus> status = new ConcurrentHashMap<>();
+
+    @Inject
+    ManagedExecutor managedExecutorService;
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = REQUIRES_NEW, timeLimit = 200)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, @QueryParam(BASE_URL_PARAM) URL baseUrl)
+            throws URISyntaxException, InterruptedException, ExecutionException {
+        log.infov("\033[0;1m\u001B[33mStarting LRA with ID {0}", lraId);
+        log.infov("\033[0;1m\u001B[33mReceived base URL from client: {0}", baseUrl);
+
+        log.infov("\033[0;1m\u001B[33mInitiator calling client 1 at {0}{1}/{2}", baseUrl.toURI(), LRA_PARTICIPANT2_PATH,
+                TRANSACTIONAL2_START_PATH);
+
+        Future<Response> futureResponse1 = managedExecutorService.submit(() -> ClientBuilder.newClient()
+                .target(baseUrl.toURI())
+                .path(LRA_PARTICIPANT2_PATH)
+                .path(TRANSACTIONAL2_START_PATH)
+                .request()
+                .get());
+
+        log.infov("\033[0;1m\u001B[33mInitiator calling client 2 at {0}{1}/{2}", baseUrl.toURI(), LRA_PARTICIPANT3_PATH,
+                TRANSACTIONAL3_START_PATH);
+
+        Future<Response> futureResponse2 = managedExecutorService.submit(() -> ClientBuilder.newClient()
+                .target(baseUrl.toURI())
+                .path(LRA_PARTICIPANT3_PATH)
+                .path(TRANSACTIONAL3_START_PATH)
+                .request()
+                .get());
+
+        // Small sleep to give the logging some chance to appear in order. Not technically needed.
+        Thread.sleep(200);
+
+        String response1 = futureResponse1.get().readEntity(String.class);
+
+        log.infov("\033[0;1m\u001B[33mInitiator received response from client 1: {0}", response1);
+
+        String response2 = futureResponse2.get().readEntity(String.class);
+
+        log.infov("\033[0;1m\u001B[33mInitiator received response from client 2: {0}", response2);
+
+        if (!"Client1".equals(response1) || !"Client2".equals(response2)) {
+            log.infov("\033[0;1m\u001B[33m Unexpected responses: initiator returning status 500");
+            return Response.status(500).entity(lraId.toASCIIString()).build();
+        }
+
+        log.infov("\033[0;1m\u001B[33mExpected responses: initiator returning status 200");
+        return Response.status(200).entity(lraId.toASCIIString()).build();
+
+    }
+
+    @PUT
+    @Path("after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[33m@Initiator AfterLRA called for {0} with LRAStatus {1}", lraId, lraStatus);
+
+        status.put(lraId, lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/quarkus/context/build/src/main/java/io/narayana/lra/arquillian/quarkus/resource/Shutdown.java
+++ b/test/quarkus/context/build/src/main/java/io/narayana/lra/arquillian/quarkus/resource/Shutdown.java
@@ -1,0 +1,26 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.quarkus.resource;
+
+import io.quarkus.runtime.Quarkus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+@Path("")
+public class Shutdown {
+
+    @GET
+    @Path("/shutdown")
+    public Response shutdown() {
+        Quarkus.asyncExit(); // triggers Quarkus shutdown
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/quarkus/context/build/src/main/resources/application.properties
+++ b/test/quarkus/context/build/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.http.port=9080
+
+quarkus.lra.coordinator-url=http://localhost:8080/lra-coordinator/lra-coordinator

--- a/test/quarkus/context/pom.xml
+++ b/test/quarkus/context/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.lra</groupId>
+    <artifactId>lra-test-quarkus</artifactId>
+    <version>1.0.4.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>lra-test-quarkus-context</artifactId>
+  <packaging>pom</packaging>
+
+  <name>LRA tests: Quarkus Context</name>
+
+  <modules>
+    <module>build</module>
+    <module>test</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <skip.wildfly.plugin>false</skip.wildfly.plugin>
+  </properties>
+</project>

--- a/test/quarkus/context/test/pom.xml
+++ b/test/quarkus/context/test/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.lra</groupId>
+    <artifactId>lra-test-quarkus-context</artifactId>
+    <version>1.0.4.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lra-test-quarkus-context-test</artifactId>
+
+  <name>LRA tests: Quarkus Context Test</name>
+  <description>LRA test testing with a jar for Quarkus for context propagation</description>
+
+  <properties>
+
+    <lra.initiator.host>localhost</lra.initiator.host>
+    <lra.initiator.port>9080</lra.initiator.port>
+    <quarkus.app>app.jar</quarkus.app>
+
+    <quarkus.home>${project.build.directory}/quarkus</quarkus.home>
+    <quarkus.jar>${quarkus.home}/${quarkus.app}</quarkus.jar>
+    <skip.wildfly.plugin>false</skip.wildfly.plugin>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>narayana-lra</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>lra-test-arquillian-extension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-quarkus-app</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.jboss.narayana.lra</groupId>
+                  <artifactId>lra-test-quarkus-context-build</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>${quarkus.home}</outputDirectory>
+                  <destFileName>${quarkus.app}</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>start-quarkus</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <executable>${java.home}/bin/java</executable>
+              <arguments>
+                <argument>-Dquarkus.http.host=${lra.initiator.host}</argument>
+                <argument>-Dquarkus.http.port=${lra.initiator.port}</argument>
+                <argument>-Dquarkus.lra.coordinator-url=${lra.coordinator.url}</argument>
+                <argument>-jar</argument>
+                <argument>${quarkus.jar}</argument>
+              </arguments>
+
+              <!-- Key bits -->
+              <async>true</async>
+              <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
+              <inheritIo>true</inheritIo>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <lra.initiator.host>${lra.initiator.host}</lra.initiator.host>
+            <lra.initiator.port>${lra.initiator.port}</lra.initiator.port>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>stop-quarkus</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>post-integration-test</phase>
+            <configuration>
+              <target>
+                <echo>Stopping Quarkus using: http://${lra.initiator.host}:${lra.initiator.port}/shutdown</echo>
+                <waitfor maxwait="10" maxwaitunit="second">
+                  <http requestMethod="GET" url="http://${lra.initiator.host}:${lra.initiator.port}/shutdown"></http>
+                </waitfor>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/Deployer.java
+++ b/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/Deployer.java
@@ -3,7 +3,7 @@
    SPDX-License-Identifier: Apache-2.0
  */
 
-package io.narayana.lra.arquillian;
+package io.narayana.lra.arquillian.quarkus;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;

--- a/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/LRAAsyncLRAIT.java
+++ b/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/LRAAsyncLRAIT.java
@@ -1,0 +1,83 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.quarkus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.narayana.lra.arquillian.quarkus.resource.LRAAsyncParticipant2Client1;
+import io.narayana.lra.arquillian.quarkus.resource.LRAAsyncParticipant3Client2;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class LRAAsyncLRAIT extends TestBase {
+
+    public static final String BASE_URL_PARAM = "base-url";
+
+    public static final String LRA_PARTICIPANT_PATH = "participant1-initiator";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+
+    private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LRAAsyncLRAIT.class.getName());
+
+    @ArquillianResource
+    public URL baseURL;
+
+    public String testName;
+
+    @BeforeEach
+    public void before(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
+        log.info("Running test " + testName);
+    }
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(
+                LRAAsyncLRAIT.class.getSimpleName(),
+                LRAAsyncParticipant2Client1.class,
+                LRAAsyncParticipant3Client2.class);
+    }
+
+    @Test
+    public void testAfterLRACount() {
+        System.out.println("\033[0;1mTest starting LRA test with URL " + baseURL);
+
+        URI initiatorStartURI = UriBuilder.newInstance()
+                .scheme("http")
+                .host(System.getProperty("lra.initiator.host"))
+                .port(Integer.valueOf(System.getProperty("lra.initiator.port")))
+                .path(LRA_PARTICIPANT_PATH)
+                .path(TRANSACTIONAL_START_PATH)
+                .queryParam(BASE_URL_PARAM, baseURL)
+                .build();
+
+        System.out.println("\033[0;1mCalling QUARKUS initiator at " + initiatorStartURI);
+
+        try (Client client = ClientBuilder.newClient()) {
+            try (Response response = client.target(initiatorStartURI)
+                    .request()
+                    .get()) {
+
+                assertEquals(200, response.getStatus());
+                assertTrue(response.hasEntity());
+
+                System.out.println("\033[0;1mTest received 200 status from QUARKUS initiator.");
+            }
+        }
+
+    }
+
+}

--- a/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/TestBase.java
+++ b/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/TestBase.java
@@ -1,0 +1,78 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.quarkus;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.LRAData;
+import io.narayana.lra.client.internal.NarayanaLRAClient;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@RunAsClient
+@ExtendWith(ArquillianExtension.class)
+public abstract class TestBase {
+
+    public static NarayanaLRAClient lraClient;
+    public static String coordinatorUrl;
+    public static Client client;
+    public static List<URI> lrasToAfterFinish;
+
+    @BeforeAll
+    public static void beforeClass() {
+        lraClient = new NarayanaLRAClient();
+        coordinatorUrl = lraClient.getCoordinatorUrl();
+        client = ClientBuilder.newClient();
+        lrasToAfterFinish = new ArrayList<>();
+    }
+
+    @AfterEach
+    public void after() {
+        List<URI> lraURIList = lraClient.getAllLRAs().stream().map(LRAData::getLraId).collect(Collectors.toList());
+        if (lrasToAfterFinish != null) {
+            for (URI lraToFinish : lrasToAfterFinish) {
+                if (lraURIList.contains(lraToFinish)) {
+                    lraClient.cancelLRA(lraToFinish);
+                }
+            }
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    protected JsonArray getAllRecords(URI lra) {
+        String coordinatorUrl = LRAConstants.getLRACoordinatorUrl(lra) + "/";
+
+        try (Response response = client.target(coordinatorUrl).path("").request().get()) {
+            Assertions.assertTrue(response.hasEntity(), "Missing response body when querying for all LRAs");
+            String allLRAs = response.readEntity(String.class);
+
+            JsonReader jsonReader = Json.createReader(new StringReader(allLRAs));
+            return jsonReader.readArray();
+        }
+    }
+
+}

--- a/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant2Client1.java
+++ b/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant2Client1.java
@@ -1,0 +1,53 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.quarkus.resource;
+
+import static io.narayana.lra.arquillian.quarkus.resource.LRAAsyncParticipant2Client1.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant2Client1 {
+    public static final String LRA_PARTICIPANT_PATH = "participant2-client1";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant2Client1.class);
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = MANDATORY, end = false, timeLimit = 100)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[34mLRAAsyncParticipant2Client1 Joining LRA with ID {0}", lraId);
+
+        return Response.ok("Client1").build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[34m@LRAAsyncParticipant2Client1 AfterLRA called for {0} with LRAStatus {1}", lraId,
+                lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant3Client2.java
+++ b/test/quarkus/context/test/src/test/java/io/narayana/lra/arquillian/quarkus/resource/LRAAsyncParticipant3Client2.java
@@ -1,0 +1,53 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.quarkus.resource;
+
+import static io.narayana.lra.arquillian.quarkus.resource.LRAAsyncParticipant3Client2.LRA_PARTICIPANT_PATH;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+@Path(LRA_PARTICIPANT_PATH)
+public class LRAAsyncParticipant3Client2 {
+    public static final String LRA_PARTICIPANT_PATH = "participant3-client2";
+    public static final String TRANSACTIONAL_START_PATH = "start-work";
+    public static final String LRA_END_STATUS = "lra-end-status";
+
+    private static final Logger log = Logger.getLogger(LRAAsyncParticipant3Client2.class);
+
+    @GET
+    @Path(TRANSACTIONAL_START_PATH)
+    @LRA(value = MANDATORY, end = false, timeLimit = 100)
+    public Response start(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.infov("\033[0;1m\u001B[32mLRAAsyncParticipant3Client2 Joining LRA with ID {0}", lraId);
+
+        return Response.ok("Client2").build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA
+    public Response after(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus lraStatus) {
+        log.infov("\033[0;1m\u001B[32m@LRAAsyncParticipant3Client2 AfterLRA called for {0} with LRAStatus {1}", lraId,
+                lraStatus);
+
+        return Response.ok().build();
+    }
+
+}

--- a/test/quarkus/context/test/src/test/resources/META-INF/services/jakarta.ws.rs.client.ClientBuilder
+++ b/test/quarkus/context/test/src/test/resources/META-INF/services/jakarta.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl

--- a/test/quarkus/context/test/src/test/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/test/quarkus/context/test/src/test/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,0 +1,2 @@
+io.narayana.lra.filter.ClientLRAResponseFilter
+io.narayana.lra.filter.ClientLRARequestFilter

--- a/test/quarkus/context/test/src/test/resources/arquillian-wildfly.xml
+++ b/test/quarkus/context/test/src/test/resources/arquillian-wildfly.xml
@@ -12,7 +12,7 @@
         <configuration>
             <!-- -Djboss.socket.binding.port-offset=100 shifts ports in Wildfly. This is used to avoid overlapping between the two instances of Wildfly-->
             <property name="jbossHome">${wildfly.home}</property>
-            <property name="javaVmArguments">${server.jvm.args} ${lra.participant.debug.params} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
+            <property name="javaVmArguments">${server.jvm.args} ${lra.coordinator.debug.params} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
             <property name="managementAddress">${test.application.host}</property>
             <property name="managementPort">10090</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/test/quarkus/pom.xml
+++ b/test/quarkus/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.narayana.lra</groupId>
+    <artifactId>lra-test</artifactId>
+    <version>1.0.4.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>lra-test-quarkus</artifactId>
+  <packaging>pom</packaging>
+
+  <name>LRA tests: Quarkus</name>
+
+  <modules>
+    <module>context</module>
+  </modules>
+
+  <properties>
+    <!-- TCK TckTests#timeLimit test needs a short, but non zero, delay -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <skip.wildfly.plugin>false</skip.wildfly.plugin>
+  </properties>
+
+</project>


### PR DESCRIPTION
Propagate the LRA ID when using a managed executor service
Includes a Jakarta EE provider and specifically for Quarkus a provider
based on MicroProfile Context Propagation. See #126 

Main code is in ClientLRAContextProviderEE

Includes tests in a variation for WildFly, and an extra test (in an
extra test folder) for Quarkus (using WildFly for the coordinator and
for hosting the services being called from the initiating LRA on
Quarkus)

The async test (doing two requests right after each other to different
services on the same WildFly instance) triggered a race condition in
Current. This is fixed as well.

See https://github.com/jbosstm/jboss-as/pull/100 for a new (optional) dependency on Jakarta Concurrency.
