### PR TITLE
Bump io.smallrye.config:smallrye-config from 3.15.1 to 3.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
     <version.io.netty>4.2.9.Final</version.io.netty>
 
-    <version.io.smallrye.smallrye-config>3.15.1</version.io.smallrye.smallrye-config>
+    <version.io.smallrye.smallrye-config>3.16.0</version.io.smallrye.smallrye-config>
     <version.io.smallrye.smallrye-stork>2.7.7</version.io.smallrye.smallrye-stork>
     <version.jakarta.concurrent>3.1.1</version.jakarta.concurrent>
     <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
@@ -160,7 +160,6 @@
     <version.org.sonatype.plugins.nxrm3.plugin>1.0.13</version.org.sonatype.plugins.nxrm3.plugin>
     <version.org.wildfly.arquillian>5.1.0.Final</version.org.wildfly.arquillian>
     <version.parsson>1.1.7</version.parsson>
-    <version.quarkus>3.31.1</version.quarkus>
     <version.sortpom>4.0.0</version.sortpom>
     <version.undertow.core>2.3.22.Final</version.undertow.core>
     <version.wildfly-maven-plugin>5.1.5.Final</version.wildfly-maven-plugin>

--- a/test/quarkus/context/build/pom.xml
+++ b/test/quarkus/context/build/pom.xml
@@ -28,17 +28,6 @@
     <quarkus.platform.version>${version.quarkus}</quarkus.platform.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.quarkus.platform</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${quarkus.platform.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <!-- Core DI -->
     <dependency>

--- a/test/quarkus/context/test/pom.xml
+++ b/test/quarkus/context/test/pom.xml
@@ -42,6 +42,7 @@
       <groupId>org.jboss.narayana.lra</groupId>
       <artifactId>lra-test-arquillian-extension</artifactId>
       <scope>test</scope>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/test/quarkus/pom.xml
+++ b/test/quarkus/pom.xml
@@ -5,15 +5,10 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <parent>
-    <groupId>org.jboss.narayana.lra</groupId>
-    <artifactId>lra-test</artifactId>
-    <version>1.0.4.Final-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
-
+    
+  <groupId>org.jboss.narayana.lra</groupId>
   <artifactId>lra-test-quarkus</artifactId>
+  <version>1.0.4.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>LRA tests: Quarkus</name>
@@ -23,7 +18,14 @@
   </modules>
 
   <properties>
-    <!-- TCK TckTests#timeLimit test needs a short, but non zero, delay -->
+    <version.quarkus>3.31.1</version.quarkus>
+        <!-- currently only defines where to search for the coordinator, it does not change where the coordinator is started -->
+    <lra.coordinator.host>localhost</lra.coordinator.host>
+    <lra.coordinator.port>8080</lra.coordinator.port>
+    <maven.compiler.release>17</maven.compiler.release>
+    <!-- the property used by NarayanaLRAClient when passed into the container as the JVM parameter -->
+    <lra.coordinator.url>http://${lra.coordinator.host}:${lra.coordinator.port}/lra-coordinator</lra.coordinator.url>
+
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <skip.wildfly.plugin>false</skip.wildfly.plugin>
   </properties>


### PR DESCRIPTION
Removing the lra parent in quarkus module to avoid dependency version discrepancies.