### PR TITLE
Catch webApplication exception in /cancel path

### DIFF
--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -42,7 +42,6 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -514,11 +513,12 @@ public class Coordinator extends Application {
             @HeaderParam(LRAConstants.NARAYANA_LRA_PARTICIPANT_LINK_HEADER_NAME) @DefaultValue("") String compensator,
             @HeaderParam(LRAConstants.NARAYANA_LRA_PARTICIPANT_DATA_HEADER_NAME) @DefaultValue("") String userData) {
 
-        LRAData lraData = lraService.endLRA(toURI(lraId), true, false, compensator, userData);
-
         try {
+            LRAData lraData = lraService.endLRA(toURI(lraId), true, false, compensator, userData);
+
             return buildResponse(lraData.getStatus().name(), version, mediaType);
-        } catch (NotFoundException e) {
+        } catch (WebApplicationException e) {
+            LRALogger.logger.debug(e.getMessage());
             return Response.status(e.getResponse().getStatus()).entity(e.getMessage()).build();
         }
     }

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -1340,7 +1340,7 @@ public class LRATest extends LRATestBase {
             @BMRule(name = "fail deactivate during close", targetClass = "io.narayana.lra.coordinator.domain.model.LongRunningAction", targetMethod = "updateState(LRAStatus, boolean)", targetLocation = "AFTER INVOKE deactivate", action = "$! = false;")
     })
     public void testCancelFailure() {
-        testEndFailure(true);
+        testEndFailure(false);
     }
 
     public void testEndFailure(boolean closeLRA) {


### PR DESCRIPTION
Apply the same logic present in the /close path to the /cancel path to catch 503 errors
Fixing testCancelFailure test which was not actually cancelling 