### PR TITLE
Use resteasy version consistently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,10 +245,30 @@
         <version>${version.jboss-modules}</version>
       </dependency>
 
-      <!-- undertow with RestEasy -->
+      <!-- RestEasy -->
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-client</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-client-api</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-core</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-core-spi</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jackson2-provider</artifactId>
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
       <dependency>
@@ -363,11 +383,6 @@
         <groupId>org.eclipse.microprofile.lra</groupId>
         <artifactId>microprofile-lra-tck</artifactId>
         <version>${version.microprofile.lra}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jackson2-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/test/quarkus/context/build/pom.xml
+++ b/test/quarkus/context/build/pom.xml
@@ -38,11 +38,14 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-narayana-lra</artifactId>
-      <!-- Make it explicit that we replace narayana-lra -->
       <exclusions>
         <exclusion>
           <groupId>org.jboss.narayana.lra</groupId>
           <artifactId>narayana-lra</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -68,10 +71,26 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
   </dependencies>
 

--- a/test/quarkus/pom.xml
+++ b/test/quarkus/pom.xml
@@ -40,6 +40,12 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Use a resteasy version consistently in all submodules.
As having multiple BOMs is difficult to handle as it is not possible to exclude one in favour of the other I am proposing to exclude the dependencies that overlap from the quarkus bom.

This PR also includes the bump to resteasy 7.0.2.Final.