### PR TITLE
Jwt for secure inbound and outbound communication

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -120,6 +120,35 @@ lra.http-client.connectTimeout=5000
 lra.http-client.readTimeout=30000
 ```
 
+#### JWT Token Propagation
+
+The simplest way to propagate JWT tokens from participants to the coordinator is the
+`@PropagateToken` annotation — no configuration needed:
+
+```java
+@LRA(value = LRA.Type.REQUIRED)
+@PropagateToken
+@GET
+public Response startWork() { ... }
+```
+
+The annotation captures the inbound Bearer token (validating it has a plausible JWT
+structure) and forwards it on outbound coordinator calls automatically.
+
+Alternatively, register the filter explicitly via configuration:
+
+```properties
+lra.http-client.providers=io.narayana.lra.client.JwtTokenClientRequestFilter
+```
+
+The filter resolves the token in order:
+1. Thread-local token captured by `@PropagateToken`
+2. `JsonWebToken` via CDI (`CDI.current().select(JsonWebToken.class)`)
+3. Client configuration property `lra.jwt.token` — for non-CDI contexts
+
+This requires the `microprofile-jwt-auth-api` dependency (provided scope) and a
+MicroProfile JWT implementation in the container (WildFly, Quarkus, etc.).
+
 #### Custom Providers
 
 ```properties

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -85,6 +85,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>
@@ -96,6 +101,11 @@
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-undertow</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/client/src/main/java/io/narayana/lra/client/JwtTokenClientRequestFilter.java
+++ b/client/src/main/java/io/narayana/lra/client/JwtTokenClientRequestFilter.java
@@ -1,0 +1,41 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.client;
+
+import io.narayana.lra.BearerTokenResolver;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+/**
+ * Client-side filter that attaches a JWT Bearer token to outbound HTTP requests
+ * from LRA participants to the coordinator.
+ *
+ * <p>
+ * Token resolution is delegated to {@link BearerTokenResolver} with thread-local
+ * lookup enabled (supports {@link io.narayana.lra.PropagateToken @PropagateToken}).
+ * </p>
+ *
+ * <p>
+ * Configure via {@code @PropagateToken} (zero-config) or explicitly:
+ * </p>
+ *
+ * <pre>
+ * lra.http-client.providers=io.narayana.lra.client.JwtTokenClientRequestFilter
+ * </pre>
+ */
+public class JwtTokenClientRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String token = BearerTokenResolver.resolve(requestContext, true);
+
+        if (token != null && !token.isEmpty()) {
+            requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+    }
+}

--- a/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -328,6 +328,7 @@ public class NarayanaLRAClient implements Closeable {
             return response.readEntity(new GenericType<List<LRAData>>() {
             });
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            rethrowIfUnauthorized(e);
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
                     .entity("getAllLRAs client request timed out, try again later").build());
         }
@@ -462,7 +463,7 @@ public class NarayanaLRAClient implements Closeable {
                 return lra;
 
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                // Handle connection exceptions, async timeout, and execution failures
+                rethrowIfUnauthorized(e);
                 Throwable t = e.getCause();
 
                 if (!supportsFailover) {
@@ -592,6 +593,7 @@ public class NarayanaLRAClient implements Closeable {
                 throwGenericLRAException(null, response.getStatus(), logMsg, null);
             }
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            rethrowIfUnauthorized(e);
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
                     .entity("leave LRA client request timed out, try again later").build());
         }
@@ -787,6 +789,7 @@ public class NarayanaLRAClient implements Closeable {
                 throw new WebApplicationException(Response.status(INTERNAL_SERVER_ERROR).entity(logMsg).build());
             }
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -837,6 +840,7 @@ public class NarayanaLRAClient implements Closeable {
 
             return response.readEntity(LRAData.class);
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -867,6 +871,7 @@ public class NarayanaLRAClient implements Closeable {
                 throw new WebApplicationException(response);
             }
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -909,6 +914,7 @@ public class NarayanaLRAClient implements Closeable {
             String statusString = response.readEntity(String.class);
             return ParticipantStatus.valueOf(statusString);
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -939,6 +945,7 @@ public class NarayanaLRAClient implements Closeable {
 
             return handleNestedEndResponse(response, nestedLraId, "completion");
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -969,6 +976,7 @@ public class NarayanaLRAClient implements Closeable {
 
             return handleNestedEndResponse(response, nestedLraId, "compensation");
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -1020,6 +1028,7 @@ public class NarayanaLRAClient implements Closeable {
                 throw new WebApplicationException(response);
             }
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
@@ -1140,6 +1149,7 @@ public class NarayanaLRAClient implements Closeable {
                 return null;
             }
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             Throwable t = e.getCause();
             if (t instanceof ServiceUnavailableException) {
                 t = (ServiceUnavailableException) t;
@@ -1199,8 +1209,8 @@ public class NarayanaLRAClient implements Closeable {
                 throw new WebApplicationException(response);
             }
         } catch (ExecutionException e) {
+            rethrowIfUnauthorized(e);
             Throwable t = e.getCause();
-            // Handle 404 not found
             if (t instanceof NotFoundException) {
                 throw (NotFoundException) t;
             }
@@ -1299,6 +1309,17 @@ public class NarayanaLRAClient implements Closeable {
     public void close() {
         if (storkInitialised) {
             Stork.shutdown();
+        }
+    }
+
+    private static void rethrowIfUnauthorized(Throwable e) throws WebApplicationException {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof WebApplicationException) {
+                int status = ((WebApplicationException) t).getResponse().getStatus();
+                if (status == Response.Status.UNAUTHORIZED.getStatusCode()) {
+                    throw (WebApplicationException) t;
+                }
+            }
         }
     }
 

--- a/client/src/main/java/io/narayana/lra/client/RestClientConfig.java
+++ b/client/src/main/java/io/narayana/lra/client/RestClientConfig.java
@@ -5,6 +5,8 @@
 
 package io.narayana.lra.client;
 
+import io.narayana.lra.Current;
+import io.narayana.lra.LRAConstants;
 import io.narayana.lra.logging.LRALogger;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -49,7 +51,7 @@ public class RestClientConfig {
     private static final String HOSTNAME_VERIFIER_KEY = CONFIG_PREFIX + "hostnameVerifier";
     private static final String CONNECT_TIMEOUT_KEY = CONFIG_PREFIX + "connectTimeout";
     private static final String READ_TIMEOUT_KEY = CONFIG_PREFIX + "readTimeout";
-    private static final String PROVIDERS_KEY = CONFIG_PREFIX + "providers";
+    private static final String PROVIDERS_KEY = LRAConstants.HTTP_CLIENT_PROVIDERS;
 
     private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
 
@@ -190,7 +192,7 @@ public class RestClientConfig {
         }
 
         try {
-            Class<?> clazz = Class.forName(className);
+            Class<?> clazz = Class.forName(className, true, Thread.currentThread().getContextClassLoader());
             return (HostnameVerifier) clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             LRALogger.logger.warnf(e, "Failed to load HostnameVerifier class %s: %s",
@@ -218,6 +220,12 @@ public class RestClientConfig {
      * Registers custom providers on the builder
      */
     private void configureProviders(RestClientBuilder builder) {
+        String authToken = Current.getAuthToken();
+        if (authToken != null) {
+            builder.property(LRAConstants.BEARER_TOKEN_PROPERTY, authToken);
+            builder.register(JwtTokenClientRequestFilter.class);
+        }
+
         String providers = getConfigValue(PROVIDERS_KEY);
         if (providers == null || providers.trim().isEmpty()) {
             return;
@@ -227,7 +235,7 @@ public class RestClientConfig {
             String trimmed = providerClassName.trim();
             if (!trimmed.isEmpty()) {
                 try {
-                    Class<?> providerClass = Class.forName(trimmed);
+                    Class<?> providerClass = Class.forName(trimmed, true, Thread.currentThread().getContextClassLoader());
                     builder.register(providerClass);
                 } catch (Exception e) {
                     LRALogger.logger.warnf(e, "Failed to load provider class %s: %s",

--- a/client/src/test/java/io/narayana/lra/client/JwtTokenClientRequestFilterTest.java
+++ b/client/src/test/java/io/narayana/lra/client/JwtTokenClientRequestFilterTest.java
@@ -1,0 +1,114 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.narayana.lra.LRAConstants;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link JwtTokenClientRequestFilter} propagates JWT Bearer tokens
+ * on outbound HTTP requests from participants to the coordinator.
+ */
+public class JwtTokenClientRequestFilterTest {
+
+    private static UndertowJaxrsServer server;
+
+    @Path("/jwt-echo")
+    public static class EchoResource {
+
+        @GET
+        public Response echoAuth(@HeaderParam(HttpHeaders.AUTHORIZATION) String auth) {
+            return Response.ok(auth != null ? auth : "").build();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class TestApp extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> classes = new HashSet<>();
+            classes.add(EchoResource.class);
+            return classes;
+        }
+    }
+
+    @BeforeAll
+    static void startServer() {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(TestApp.class);
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void tokenFromPropertyIsPropagated() {
+        String url = TestPortProvider.generateURL("/jwt-echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.property(LRAConstants.BEARER_TOKEN_PROPERTY, "participant-jwt-token");
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer participant-jwt-token", response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    void noTokenMeansNoAuthorizationHeader() {
+        String url = TestPortProvider.generateURL("/jwt-echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("", response.readEntity(String.class),
+                        "No Authorization header should be sent when no token is available");
+            }
+        }
+    }
+
+    @Test
+    void emptyTokenIsNotPropagated() {
+        String url = TestPortProvider.generateURL("/jwt-echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.property(LRAConstants.BEARER_TOKEN_PROPERTY, "");
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("", response.readEntity(String.class),
+                        "Empty token should not produce an Authorization header");
+            }
+        }
+    }
+}

--- a/client/src/test/java/io/narayana/lra/client/PropagateTokenIntegrationTest.java
+++ b/client/src/test/java/io/narayana/lra/client/PropagateTokenIntegrationTest.java
@@ -1,0 +1,271 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.narayana.lra.AnnotationResolver;
+import io.narayana.lra.BearerTokenResolver;
+import io.narayana.lra.Current;
+import io.narayana.lra.PropagateToken;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration-style test that verifies the full {@code @PropagateToken} flow:
+ * annotation detection (same logic as {@code ServerLRAFilter}), structural JWT
+ * validation, token capture into {@link Current}, and propagation via
+ * {@link JwtTokenClientRequestFilter} to an outbound HTTP call.
+ */
+public class PropagateTokenIntegrationTest {
+
+    private static final String VALID_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature";
+    private static UndertowJaxrsServer server;
+
+    // --- Real annotated resource classes ---
+
+    @Path("/participant")
+    @PropagateToken
+    public static class ClassLevelAnnotatedParticipant {
+
+        @GET
+        @Path("/action")
+        public Response action() {
+            return Response.ok().build();
+        }
+    }
+
+    @Path("/participant2")
+    public static class MethodLevelAnnotatedParticipant {
+
+        @PropagateToken
+        @GET
+        @Path("/action")
+        public Response action() {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/no-propagate")
+        public Response noPropagate() {
+            return Response.ok().build();
+        }
+    }
+
+    @Path("/echo")
+    public static class EchoResource {
+
+        @GET
+        public Response echoAuth(@HeaderParam(HttpHeaders.AUTHORIZATION) String auth) {
+            return Response.ok(auth != null ? auth : "").build();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class TestApp extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> classes = new HashSet<>();
+            classes.add(EchoResource.class);
+            return classes;
+        }
+    }
+
+    @BeforeAll
+    static void startServer() {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(TestApp.class);
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @AfterEach
+    void cleanup() {
+        Current.clearAuthToken();
+    }
+
+    /**
+     * Simulates exactly what ServerLRAFilter does: detect annotation, extract
+     * Bearer token, validate JWT structure, store in Current.
+     */
+    private static void simulateServerLRAFilter(Method method, String authHeader) {
+        if (AnnotationResolver.isAnnotationPresent(PropagateToken.class, method)
+                || method.getDeclaringClass().isAnnotationPresent(PropagateToken.class)) {
+            if (authHeader != null && authHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+                String token = authHeader.substring(7);
+                if (BearerTokenResolver.isPlausibleJwt(token)) {
+                    Current.setAuthToken(token);
+                }
+            }
+        }
+    }
+
+    // --- Annotation detection tests ---
+
+    @Test
+    void annotationDetectedOnMethod() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        assertTrue(AnnotationResolver.isAnnotationPresent(PropagateToken.class, method));
+    }
+
+    @Test
+    void annotationNotDetectedOnUnannotatedMethod() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("noPropagate");
+        assertFalse(AnnotationResolver.isAnnotationPresent(PropagateToken.class, method));
+    }
+
+    @Test
+    void annotationDetectedOnClassAppliesToAllMethods() throws Exception {
+        Method method = ClassLevelAnnotatedParticipant.class.getMethod("action");
+        assertTrue(method.getDeclaringClass().isAnnotationPresent(PropagateToken.class));
+    }
+
+    // --- Full flow tests ---
+
+    @Test
+    void fullFlowWithMethodAnnotation() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer " + VALID_JWT);
+
+        assertNotNull(Current.getAuthToken());
+
+        String url = TestPortProvider.generateURL("/echo");
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer " + VALID_JWT, response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    void fullFlowWithClassAnnotation() throws Exception {
+        Method method = ClassLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer " + VALID_JWT);
+
+        assertNotNull(Current.getAuthToken());
+
+        String url = TestPortProvider.generateURL("/echo");
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer " + VALID_JWT, response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    void unannotatedMethodDoesNotCaptureToken() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("noPropagate");
+        simulateServerLRAFilter(method, "Bearer " + VALID_JWT);
+
+        assertNull(Current.getAuthToken());
+
+        String url = TestPortProvider.generateURL("/echo");
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("", response.readEntity(String.class));
+            }
+        }
+    }
+
+    // --- Structural validation tests ---
+
+    @Test
+    void nonBearerAuthHeaderIsIgnored() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Basic dXNlcjpwYXNz");
+
+        assertNull(Current.getAuthToken());
+    }
+
+    @Test
+    void malformedJwtIsRejected() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer not-a-jwt-at-all");
+
+        assertNull(Current.getAuthToken(), "Token without three dot-separated segments should be rejected");
+    }
+
+    @Test
+    void opaqueTokenIsRejected() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer abc123def456");
+
+        assertNull(Current.getAuthToken(), "Opaque (non-JWT) Bearer token should be rejected");
+    }
+
+    @Test
+    void twoSegmentTokenIsRejected() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer header.payload");
+
+        assertNull(Current.getAuthToken(), "Two-segment token is not a valid JWS");
+    }
+
+    @Test
+    void fourSegmentTokenIsRejected() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer a.b.c.d");
+
+        assertNull(Current.getAuthToken(), "Four-segment token is not a valid JWS");
+    }
+
+    @Test
+    void validThreeSegmentJwtIsAccepted() throws Exception {
+        Method method = MethodLevelAnnotatedParticipant.class.getMethod("action");
+        simulateServerLRAFilter(method, "Bearer header.payload.signature");
+
+        assertNotNull(Current.getAuthToken());
+        assertEquals("header.payload.signature", Current.getAuthToken());
+    }
+
+    // --- isPlausibleJwt unit tests ---
+
+    @Test
+    void isPlausibleJwtValidatesStructure() {
+        assertTrue(BearerTokenResolver.isPlausibleJwt("a.b.c"));
+        assertTrue(BearerTokenResolver.isPlausibleJwt("eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig"));
+        assertFalse(BearerTokenResolver.isPlausibleJwt("no-dots"));
+        assertFalse(BearerTokenResolver.isPlausibleJwt("one.dot"));
+        assertFalse(BearerTokenResolver.isPlausibleJwt("too.many.dots.here"));
+        assertFalse(BearerTokenResolver.isPlausibleJwt(".empty.header"));
+        assertFalse(BearerTokenResolver.isPlausibleJwt("empty..signature"));
+    }
+}

--- a/client/src/test/java/io/narayana/lra/client/PropagateTokenTest.java
+++ b/client/src/test/java/io/narayana/lra/client/PropagateTokenTest.java
@@ -1,0 +1,167 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.narayana.lra.Current;
+import io.narayana.lra.LRAConstants;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@code @PropagateToken} captures the inbound Bearer token in
+ * {@link Current#setAuthToken(String)} and that the filter and auto-registration
+ * pick it up for outbound calls.
+ */
+public class PropagateTokenTest {
+
+    private static UndertowJaxrsServer server;
+
+    @Path("/echo")
+    public static class EchoResource {
+
+        @GET
+        public Response echoAuth(@HeaderParam(HttpHeaders.AUTHORIZATION) String auth) {
+            return Response.ok(auth != null ? auth : "").build();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class TestApp extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> classes = new HashSet<>();
+            classes.add(EchoResource.class);
+            return classes;
+        }
+    }
+
+    @BeforeAll
+    static void startServer() {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(TestApp.class);
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @AfterEach
+    void cleanup() {
+        Current.clearAuthToken();
+    }
+
+    @Test
+    void filterUsesTokenFromCurrent() {
+        Current.setAuthToken("propagated-jwt");
+        String url = TestPortProvider.generateURL("/echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer propagated-jwt", response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    void currentTokenTakesPrecedenceOverClientProperty() {
+        Current.setAuthToken("from-annotation");
+        String url = TestPortProvider.generateURL("/echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.property(LRAConstants.BEARER_TOKEN_PROPERTY, "from-property");
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer from-annotation", response.readEntity(String.class),
+                        "@PropagateToken token should take precedence over client property");
+            }
+        }
+    }
+
+    @Test
+    void clearAuthTokenRemovesToken() {
+        Current.setAuthToken("temporary");
+        Current.clearAuthToken();
+        assertNull(Current.getAuthToken());
+
+        String url = TestPortProvider.generateURL("/echo");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenClientRequestFilter.class);
+
+            try (Response response = client.target(url).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("", response.readEntity(String.class),
+                        "No token should be sent after clearAuthToken()");
+            }
+        }
+    }
+
+    @Test
+    void restClientConfigAutoRegistersFilterWhenTokenPresent() {
+        Current.setAuthToken("auto-registered");
+        String baseUrl = TestPortProvider.generateURL("/");
+
+        EchoClient echoClient = new RestClientConfig()
+                .configure(RestClientBuilder.newBuilder().baseUri(java.net.URI.create(baseUrl)))
+                .build(EchoClient.class);
+
+        try (Response response = echoClient.echo().toCompletableFuture().join()) {
+            assertEquals(200, response.getStatus());
+            assertEquals("Bearer auto-registered", response.readEntity(String.class),
+                    "RestClientConfig should auto-register filter when Current.getAuthToken() is set");
+        }
+    }
+
+    @Test
+    void restClientConfigDoesNotRegisterFilterWithoutToken() {
+        String baseUrl = TestPortProvider.generateURL("/");
+
+        EchoClient echoClient = new RestClientConfig()
+                .configure(RestClientBuilder.newBuilder().baseUri(java.net.URI.create(baseUrl)))
+                .build(EchoClient.class);
+
+        try (Response response = echoClient.echo().toCompletableFuture().join()) {
+            assertEquals(200, response.getStatus());
+            assertEquals("", response.readEntity(String.class),
+                    "No Authorization header without token or filter configured");
+        }
+    }
+
+    @Path("/echo")
+    public interface EchoClient {
+
+        @GET
+        java.util.concurrent.CompletionStage<Response> echo();
+    }
+}

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -137,6 +137,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana.lra</groupId>
       <artifactId>narayana-lra</artifactId>
       <scope>test</scope>

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -37,6 +37,7 @@ import io.narayana.lra.LRAData;
 import io.narayana.lra.coordinator.domain.model.LongRunningAction;
 import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.narayana.lra.coordinator.internal.LRARecoveryModule;
+import io.narayana.lra.coordinator.security.JwtTokenContext;
 import io.narayana.lra.logging.LRALogger;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.json.Json;
@@ -54,7 +55,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Context;
@@ -307,7 +307,7 @@ public class Coordinator extends Application {
 
             if (!lraService.hasTransaction(parentId)) {
 
-                try (Client client = ClientBuilder.newClient()) {
+                try (Client client = JwtTokenContext.newClient()) {
                     try (Response response = client.target(parentId)
                             .request()
                             .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, CURRENT_API_VERSION_STRING)

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
@@ -23,11 +23,11 @@ import io.narayana.lra.Current;
 import io.narayana.lra.LRAConstants;
 import io.narayana.lra.LRAData;
 import io.narayana.lra.coordinator.domain.service.LRAService;
+import io.narayana.lra.coordinator.security.JwtTokenContext;
 import io.narayana.lra.logging.LRALogger;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.AsyncInvoker;
 import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
@@ -342,7 +342,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
 
             try {
                 // ask the participant to complete or compensate
-                client = ClientBuilder.newClient();
+                client = JwtTokenContext.newClient();
                 Response response = client.target(endPath)
                         .request()
                         .header(LRA_HTTP_CONTEXT_HEADER, lraId.toASCIIString())
@@ -449,7 +449,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
 
     private boolean afterLRARequest(URI target, String payload) {
 
-        try (Client client = ClientBuilder.newClient()) {
+        try (Client client = JwtTokenContext.newClient()) {
             Invocation.Builder builder = client.target(target)
                     .request()
                     .header(LRA_HTTP_RECOVERY_HEADER, recoveryURI.toASCIIString())
@@ -615,7 +615,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
             // it is a standard participant - check the status URI
             Response response;
 
-            try (Client client = ClientBuilder.newClient()) {
+            try (Client client = JwtTokenContext.newClient()) {
                 // since this method is called from the recovery thread do not block
                 response = client.target(statusURI)//.path(getLRAId(lraId))
                         .request()
@@ -800,7 +800,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
 
         if (forgetURI != null) {
             try {
-                client = ClientBuilder.newClient();
+                client = JwtTokenContext.newClient();
                 Response response = client.target(forgetURI)//.path(getLRAId(lraId))
                         .request()
                         .header(LRA_HTTP_CONTEXT_HEADER, lraId)

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/security/JwtTokenCallbackRequestFilter.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/security/JwtTokenCallbackRequestFilter.java
@@ -1,0 +1,42 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import io.narayana.lra.BearerTokenResolver;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+/**
+ * Client-side filter that attaches a JWT Bearer token to outbound HTTP requests
+ * from the coordinator to participant callbacks (compensate, complete, status, forget, afterLRA).
+ *
+ * <p>
+ * Token resolution is delegated to {@link BearerTokenResolver} without thread-local
+ * lookup (the coordinator uses CDI or the client property set by
+ * {@link JwtTokenContext#newClient()}).
+ * </p>
+ *
+ * <p>
+ * Register via:
+ * </p>
+ *
+ * <pre>
+ * lra.http-client.providers=io.narayana.lra.coordinator.security.JwtTokenCallbackRequestFilter
+ * </pre>
+ */
+public class JwtTokenCallbackRequestFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        String token = BearerTokenResolver.resolve(requestContext, false);
+
+        if (token != null && !token.isEmpty()) {
+            requestContext.getHeaders().putSingle(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+    }
+}

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/security/JwtTokenContext.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/security/JwtTokenContext.java
@@ -1,0 +1,130 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.logging.LRALogger;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * Creates configured JAX-RS {@link Client} instances for outbound participant calls.
+ *
+ * <p>
+ * Provider classes listed in the {@code lra.http-client.providers} MicroProfile Config
+ * property are registered on every client produced by {@link #newClient()}. This is the
+ * same configuration key used by {@code RestClientConfig} in the lra-client module,
+ * so a single property controls both NarayanaLRAClient and coordinator outbound calls.
+ *
+ * <p>
+ * Token resolution order in {@link #newClient()}:
+ * <ol>
+ * <li>Inbound token from {@code JsonWebToken} via CDI (propagated from the caller's request)</li>
+ * <li>Service token from {@link ServiceTokenProvider} (for recovery threads with no
+ * inbound request, configured via {@code lra.security.service-token.location})</li>
+ * </ol>
+ */
+public final class JwtTokenContext {
+
+    private static final String PROVIDERS_KEY = LRAConstants.HTTP_CLIENT_PROVIDERS;
+
+    private static final List<Class<?>> providers = loadProviders();
+
+    private static final ServiceTokenProvider serviceTokenProvider = ServiceTokenProvider.fromConfig();
+
+    private JwtTokenContext() {
+    }
+
+    /**
+     * Creates a new JAX-RS {@link Client} with all providers from the
+     * {@code lra.http-client.providers} configuration registered.
+     *
+     * <p>
+     * If a JWT token is available via CDI ({@code JsonWebToken} from the inbound
+     * request), it is stored as a client configuration property. Otherwise, if a
+     * {@link ServiceTokenProvider} is configured, a service token is read from the
+     * configured location. This ensures that outbound calls from the recovery thread
+     * (where no CDI request scope exists) can still authenticate to participants.
+     */
+    public static Client newClient() {
+        Client client = ClientBuilder.newClient();
+
+        String token = null;
+
+        if (!providers.isEmpty()) {
+            token = getTokenFromCDI();
+        }
+
+        if (token == null && serviceTokenProvider != null) {
+            token = serviceTokenProvider.getToken();
+        }
+
+        if (token != null) {
+            client.property(LRAConstants.BEARER_TOKEN_PROPERTY, token);
+        }
+
+        for (Class<?> provider : providers) {
+            client.register(provider);
+        }
+
+        return client;
+    }
+
+    private static String getTokenFromCDI() {
+        try {
+            JsonWebToken jwt = CDI.current().select(JsonWebToken.class).get();
+            String rawToken = jwt.getRawToken();
+            if (rawToken != null) {
+                if (LRALogger.logger.isTraceEnabled()) {
+                    LRALogger.logger.trace("JWT token resolved from CDI for outbound call");
+                }
+            }
+            return rawToken;
+        } catch (IllegalStateException e) {
+            if (LRALogger.logger.isDebugEnabled()) {
+                LRALogger.logger.debugf("CDI JsonWebToken not available: %s", e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    private static List<Class<?>> loadProviders() {
+        String providersStr;
+
+        try {
+            providersStr = ConfigProvider.getConfig().getValue(PROVIDERS_KEY, String.class);
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+
+        if (providersStr == null || providersStr.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Class<?>> result = new ArrayList<>();
+
+        for (String className : providersStr.split(",")) {
+            String trimmed = className.trim();
+
+            if (!trimmed.isEmpty()) {
+                try {
+                    result.add(Class.forName(trimmed));
+                } catch (Exception e) {
+                    LRALogger.logger.warnf(e, "Failed to load provider class %s: %s",
+                            trimmed, e.getMessage());
+                }
+            }
+        }
+
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/security/ServiceTokenProvider.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/security/ServiceTokenProvider.java
@@ -1,0 +1,158 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.logging.LRALogger;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * Reads a pre-provisioned JWT token from a file, classpath resource, or HTTP endpoint.
+ * Used by {@link JwtTokenContext#newClient()} as a fallback when no inbound Bearer
+ * token is available (e.g., on the recovery thread).
+ *
+ * <p>
+ * The token is cached and re-read from the source after a configurable interval
+ * (default 300 seconds) to support external rotation (e.g., Kubernetes projected
+ * volumes, Vault Agent sidecars).
+ *
+ * <p>
+ * Supported location schemes:
+ * <ul>
+ * <li>{@code file:///var/run/secrets/token} — filesystem path</li>
+ * <li>{@code classpath://META-INF/service-token} — classpath resource</li>
+ * <li>{@code http://} or {@code https://} — HTTP GET to a token endpoint</li>
+ * <li>Plain path (no scheme) — treated as a filesystem path</li>
+ * </ul>
+ *
+ * <p>
+ * Configuration:
+ * <ul>
+ * <li>{@code lra.security.service-token.location} — token source (required)</li>
+ * <li>{@code lra.security.service-token.refresh-seconds} — cache TTL in seconds (default 300)</li>
+ * </ul>
+ */
+final class ServiceTokenProvider {
+
+    private static final int DEFAULT_REFRESH_SECONDS = 300;
+
+    private final String location;
+    private final long refreshMillis;
+
+    private String cachedToken;
+    private long expiresAtMillis;
+
+    private ServiceTokenProvider(String location, long refreshSeconds) {
+        this.location = location;
+        this.refreshMillis = refreshSeconds * 1000L;
+    }
+
+    static ServiceTokenProvider fromConfig() {
+        String location = getStringConfig(LRAConstants.SERVICE_TOKEN_LOCATION);
+
+        if (location == null) {
+            return null;
+        }
+
+        long refreshSeconds = getLongConfig(LRAConstants.SERVICE_TOKEN_REFRESH_SECONDS, DEFAULT_REFRESH_SECONDS);
+
+        LRALogger.logger.info(LRALogger.i18nLogger.info_serviceTokenProviderConfigured(location, refreshSeconds));
+
+        return new ServiceTokenProvider(location, refreshSeconds);
+    }
+
+    synchronized String getToken() {
+        if (cachedToken != null && System.currentTimeMillis() < expiresAtMillis) {
+            return cachedToken;
+        }
+
+        try {
+            cachedToken = readToken();
+            expiresAtMillis = System.currentTimeMillis() + refreshMillis;
+        } catch (Exception e) {
+            LRALogger.i18nLogger.warn_failedToReadServiceToken(location, e.getMessage(), e);
+            cachedToken = null;
+        }
+
+        return cachedToken;
+    }
+
+    private String readToken() throws Exception {
+        if (location.startsWith("http://") || location.startsWith("https://")) {
+            return readFromHttp();
+        }
+
+        try (InputStream is = openResource()) {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8).trim();
+        }
+    }
+
+    private InputStream openResource() throws Exception {
+        if (location.startsWith("classpath://")) {
+            String resourcePath = location.substring("classpath://".length());
+            InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourcePath);
+            if (stream == null) {
+                throw new IllegalArgumentException("Classpath resource not found: " + resourcePath);
+            }
+            return stream;
+        } else if (location.startsWith("file://")) {
+            return new FileInputStream(location.substring("file://".length()));
+        } else {
+            return new FileInputStream(location);
+        }
+    }
+
+    private static final int MAX_TOKEN_SIZE = 64 * 1024;
+    private static final int HTTP_CONNECT_TIMEOUT_MS = 5000;
+    private static final int HTTP_READ_TIMEOUT_MS = 5000;
+
+    private String readFromHttp() throws Exception {
+        HttpURLConnection connection = (HttpURLConnection) URI.create(location).toURL().openConnection();
+
+        try {
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
+            connection.setReadTimeout(HTTP_READ_TIMEOUT_MS);
+            int status = connection.getResponseCode();
+
+            if (status != 200) {
+                throw new RuntimeException("Token endpoint returned HTTP " + status);
+            }
+
+            InputStream in = connection.getInputStream();
+            byte[] buf = in.readNBytes(MAX_TOKEN_SIZE + 1);
+            if (buf.length > MAX_TOKEN_SIZE) {
+                throw new RuntimeException("Token response exceeds maximum size of " + MAX_TOKEN_SIZE + " bytes");
+            }
+
+            return new String(buf, StandardCharsets.UTF_8).trim();
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private static String getStringConfig(String key) {
+        try {
+            String value = ConfigProvider.getConfig().getValue(key, String.class);
+            return (value != null && !value.isEmpty()) ? value : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static long getLongConfig(String key, long defaultValue) {
+        try {
+            return ConfigProvider.getConfig().getValue(key, Long.class);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+}

--- a/coordinator/src/main/resources/META-INF/microprofile-config.properties
+++ b/coordinator/src/main/resources/META-INF/microprofile-config.properties
@@ -8,3 +8,16 @@ lra.participant.data=true
 
 # max number of tasks in coordinator's queue (default 10)
 #io.narayana.lra.coordinator.api.Coordinator/startLRA/Bulkhead/waitingTaskQueue=10
+
+# Comma-separated list of provider class names to register on outbound HTTP clients.
+# Same config key as used by RestClientConfig in lra-client.
+# To enable JWT token propagation to participant callbacks:
+#lra.http-client.providers=io.narayana.lra.coordinator.security.JwtTokenCallbackRequestFilter
+
+# Service token for recovery thread authentication.
+# When the coordinator's recovery thread retries participant callbacks, no inbound
+# request exists so the caller's JWT cannot be propagated. This token is read from
+# the configured location and used as a fallback.
+# Supported schemes: file://, classpath://, http://, https://, or a plain filesystem path.
+#lra.security.service-token.location=/var/run/secrets/lra/token
+#lra.security.service-token.refresh-seconds=300

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/security/JwtTokenPropagationTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/security/JwtTokenPropagationTest.java
@@ -1,0 +1,108 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.narayana.lra.LRAConstants;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests outbound JWT token propagation via {@link JwtTokenCallbackRequestFilter}.
+ * The filter reads the token from a client configuration property
+ * ({@value LRAConstants#BEARER_TOKEN_PROPERTY}) and adds it as a Bearer header.
+ */
+public class JwtTokenPropagationTest {
+
+    private static UndertowJaxrsServer server;
+
+    @Path("/jwt-test")
+    public static class JwtTestResource {
+
+        @GET
+        @Path("/echo-auth")
+        public Response echoAuth(@HeaderParam(HttpHeaders.AUTHORIZATION) String auth) {
+            return Response.ok(auth != null ? auth : "").build();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class TestApp extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> classes = new HashSet<>();
+            classes.add(JwtTestResource.class);
+            return classes;
+        }
+    }
+
+    @BeforeAll
+    static void startServer() {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(TestApp.class);
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void testClientFilterAddsAuthorizationFromProperty() {
+        String echoUrl = TestPortProvider.generateURL("/jwt-test/echo-auth");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.property(LRAConstants.BEARER_TOKEN_PROPERTY, "my-jwt-token");
+            client.register(JwtTokenCallbackRequestFilter.class);
+
+            try (Response response = client.target(echoUrl).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("Bearer my-jwt-token", response.readEntity(String.class));
+            }
+        }
+    }
+
+    @Test
+    void testClientFilterNoTokenNoHeader() {
+        String echoUrl = TestPortProvider.generateURL("/jwt-test/echo-auth");
+
+        try (Client client = ClientBuilder.newClient()) {
+            client.register(JwtTokenCallbackRequestFilter.class);
+
+            try (Response response = client.target(echoUrl).request().get()) {
+                assertEquals(200, response.getStatus());
+                assertEquals("", response.readEntity(String.class),
+                        "No Authorization header should be sent when no token is available");
+            }
+        }
+    }
+
+    @Test
+    void testNewClientCreatesWorkingClient() {
+        try (Client client = JwtTokenContext.newClient()) {
+            assertNotNull(client);
+        }
+    }
+}

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/security/RecoveryTokenGapTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/security/RecoveryTokenGapTest.java
@@ -1,0 +1,41 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.narayana.lra.LRAConstants;
+import jakarta.ws.rs.client.Client;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Demonstrates that the recovery thread has no CDI request scope,
+ * so {@code CDI.current().select(JsonWebToken.class)} fails and
+ * {@link JwtTokenContext#newClient()} produces a client with no token property
+ * (unless a {@link ServiceTokenProvider} is configured).
+ *
+ * <p>
+ * The {@link ServiceTokenProviderTest} verifies that configuring a service
+ * token fills this gap.
+ */
+public class RecoveryTokenGapTest {
+
+    @Test
+    void testRecoveryThreadHasNoTokenInContext() throws Exception {
+        Thread recoveryThread = new Thread(() -> {
+            try (Client client = JwtTokenContext.newClient()) {
+                Object tokenProperty = client.getConfiguration()
+                        .getProperty(LRAConstants.BEARER_TOKEN_PROPERTY);
+                assertNull(tokenProperty,
+                        "Client created on recovery thread (no CDI scope, no service token) "
+                                + "should have no token property");
+            }
+        });
+
+        recoveryThread.start();
+        recoveryThread.join();
+    }
+}

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/security/ServiceTokenProviderTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/security/ServiceTokenProviderTest.java
@@ -1,0 +1,201 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.narayana.lra.LRAConstants;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
+import org.jboss.resteasy.test.TestPortProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class ServiceTokenProviderTest {
+
+    private static UndertowJaxrsServer server;
+
+    @TempDir
+    static File tempDir;
+
+    @Path("/token-endpoint")
+    public static class MockTokenEndpoint {
+
+        @GET
+        @Path("/token")
+        public Response token() {
+            return Response.ok("http-service-token-value").build();
+        }
+    }
+
+    @ApplicationPath("/")
+    public static class TokenServerApp extends Application {
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            Set<Class<?>> classes = new HashSet<>();
+            classes.add(MockTokenEndpoint.class);
+            return classes;
+        }
+    }
+
+    @BeforeAll
+    static void setup() {
+        server = new UndertowJaxrsServer().start();
+        server.deploy(TokenServerApp.class);
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (server != null) {
+            server.stop();
+        }
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_REFRESH_SECONDS);
+    }
+
+    @Test
+    void testReadTokenFromFile() throws Exception {
+        File tokenFile = new File(tempDir, "token");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("file-based-token-value");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, tokenFile.getAbsolutePath());
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertNotNull(provider);
+        assertEquals("file-based-token-value", provider.getToken());
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+
+    @Test
+    void testReadTokenFromFileUri() throws Exception {
+        File tokenFile = new File(tempDir, "token-uri");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("file-uri-token-value\n");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, "file://" + tokenFile.getAbsolutePath());
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertNotNull(provider);
+        assertEquals("file-uri-token-value", provider.getToken());
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+
+    @Test
+    void testReadTokenFromHttp() {
+        String httpUrl = TestPortProvider.generateURL("/token-endpoint/token");
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, httpUrl);
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertNotNull(provider);
+        assertEquals("http-service-token-value", provider.getToken());
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+
+    @Test
+    void testTokenIsCached() throws Exception {
+        File tokenFile = new File(tempDir, "cached-token");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("original-token");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, tokenFile.getAbsolutePath());
+        System.setProperty(LRAConstants.SERVICE_TOKEN_REFRESH_SECONDS, "3600");
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertEquals("original-token", provider.getToken());
+
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("rotated-token");
+        }
+
+        assertEquals("original-token", provider.getToken(),
+                "Cached token should be returned before refresh interval");
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_REFRESH_SECONDS);
+    }
+
+    @Test
+    void testFromConfigReturnsNullWithoutLocation() {
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertNull(provider, "Provider should be null when location is not configured");
+    }
+
+    @Test
+    void testRecoveryThreadGetsServiceToken() throws Exception {
+        File tokenFile = new File(tempDir, "recovery-token");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("recovery-service-token");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, tokenFile.getAbsolutePath());
+
+        Thread recoveryThread = new Thread(() -> {
+            ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+            assertNotNull(provider);
+            assertEquals("recovery-service-token", provider.getToken());
+        });
+
+        recoveryThread.start();
+        recoveryThread.join();
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+
+    @Test
+    void testNewClientUsesServiceTokenWhenNoInboundToken() throws Exception {
+        File tokenFile = new File(tempDir, "newclient-token");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("newclient-service-token");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, tokenFile.getAbsolutePath());
+
+        try (Client client = JwtTokenContext.newClient()) {
+            Object tokenProperty = client.getConfiguration().getProperty(LRAConstants.BEARER_TOKEN_PROPERTY);
+            assertNotNull(tokenProperty,
+                    "newClient() should read service token when no inbound token exists");
+        }
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+
+    @Test
+    void testTokenTrimsWhitespace() throws Exception {
+        File tokenFile = new File(tempDir, "whitespace-token");
+        try (FileWriter writer = new FileWriter(tokenFile)) {
+            writer.write("  clean-token  \n");
+        }
+
+        System.setProperty(LRAConstants.SERVICE_TOKEN_LOCATION, tokenFile.getAbsolutePath());
+
+        ServiceTokenProvider provider = ServiceTokenProvider.fromConfig();
+        assertEquals("clean-token", provider.getToken());
+
+        System.clearProperty(LRAConstants.SERVICE_TOKEN_LOCATION);
+    }
+}

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -12,5 +12,6 @@ include::jaxrs.adoc[]
 include::non-jaxrs.adoc[]
 include::examples.adoc[]
 include::integration.adoc[]
+include::security.adoc[]
 
 :leveloffset: -1

--- a/docs/src/main/asciidoc/security.adoc
+++ b/docs/src/main/asciidoc/security.adoc
@@ -1,0 +1,456 @@
+
+= Security
+
+The LRA project supports optional JWT-based security for three concerns:
+
+* <<inbound-authentication,Inbound authentication>> -- validating Bearer tokens on coordinator API endpoints
+  (delegated to the container's MicroProfile JWT implementation)
+* <<outbound-token-propagation,Outbound token propagation>> -- forwarding credentials when the coordinator calls
+  participant callbacks, or when participants call the coordinator
+* <<recovery-thread-service-token,Recovery thread authentication>> -- using a pre-provisioned service token
+  when no inbound request context is available
+
+[[inbound-authentication]]
+== Inbound Authentication
+
+Inbound JWT authentication is *not* implemented by the coordinator itself.
+It is the responsibility of the deployment container:
+
+* *WildFly*: configure via the Elytron subsystem and the `microprofile-jwt-smallrye` extension.
+  The LRA coordinator subsystem supports a `security-domain` attribute that wires
+  `BEARER_TOKEN` authentication on the internal coordinator deployment.
+* *Quarkus*: configure via `quarkus.smallrye-jwt.*` properties in `application.properties`.
+
+The container validates the JWT signature and claims, populates `SecurityContext`,
+and makes `JsonWebToken` available via CDI.
+
+=== WildFly Configuration
+
+Enable bearer token authentication by setting `security-domain` in the LRA coordinator subsystem:
+
+[source,xml]
+----
+<subsystem xmlns="urn:jboss:domain:microprofile-lra-coordinator:2.0"
+           security-domain="lra-bearer-security-domain"/>
+----
+
+The referenced security domain must be an Elytron `http-authentication-factory` configured for
+`BEARER_TOKEN` authentication against the `microprofile-jwt-smallrye` mechanism.
+Refer to the
+https://docs.wildfly.org/32/Admin_Guide.html#MicroProfile_JWT_SmallRye[MicroProfile JWT SmallRye subsystem documentation]
+for the complete Elytron wiring.
+
+=== Quarkus Configuration
+
+In `application.properties` (or `application.yaml`), specify the issuer and public key location:
+
+[source,properties]
+----
+mp.jwt.verify.publickey.location=META-INF/coordinator-public-key.pem
+mp.jwt.verify.issuer=https://my-idp/realms/my-realm
+----
+
+[[outbound-token-propagation]]
+== Outbound Token Propagation
+
+=== Zero-Config: `@PropagateToken`
+
+The simplest way to propagate JWT tokens is the `@PropagateToken` annotation on
+participant resource methods.
+No `lra.http-client.providers` configuration is needed:
+
+[source,java]
+----
+@LRA(value = LRA.Type.REQUIRED)
+@PropagateToken
+@GET
+public Response startWork() { ... }
+----
+
+When a request with a Bearer token hits an `@PropagateToken` method, the LRA runtime:
+
+. Captures the token from the `Authorization` header
+. Validates that it has a plausible JWT structure (three dot-separated segments)
+. Stores it in a thread-local for the duration of the request
+. Automatically registers the token filter on outbound coordinator calls
+. Clears the thread-local after the response
+
+`@PropagateToken` can be placed on individual methods or on the class (applies to all methods).
+
+=== Explicit: `lra.http-client.providers`
+
+Two filters are provided for explicit registration:
+
+[cols="1,1,2",options="header"]
+|===
+|Filter |Module |Use Case
+
+|`io.narayana.lra.client.JwtTokenClientRequestFilter`
+|`lra-client`
+|Participants calling the coordinator
+
+|`io.narayana.lra.coordinator.security.JwtTokenCallbackRequestFilter`
+|`lra-coordinator-jar`
+|Coordinator calling participant callbacks
+|===
+
+==== Participant Configuration
+
+[source,properties]
+----
+lra.http-client.providers=io.narayana.lra.client.JwtTokenClientRequestFilter
+----
+
+==== Coordinator Configuration
+
+[source,properties]
+----
+lra.http-client.providers=io.narayana.lra.coordinator.security.JwtTokenCallbackRequestFilter
+----
+
+The configuration key (`lra.http-client.providers`) is shared: `RestClientConfig` in the
+`lra-client` module reads it for the `NarayanaLRAClient`, and `JwtTokenContext` in the
+coordinator reads it for direct HTTP calls.
+
+=== Token Resolution
+
+Both filters delegate to `BearerTokenResolver`, which resolves the token from available
+sources in the following order:
+
+[cols="^1,2,2,2",options="header"]
+|===
+|Priority |Source |When Available |Used by
+
+|1
+|`@PropagateToken` thread-local
+|`@PropagateToken` on resource method
+|Client filter only
+
+|2
+|`JsonWebToken` via CDI
+|Request thread with MicroProfile JWT
+|Both filters
+
+|3
+|Client property `lra.jwt.token`
+|Set by `JwtTokenContext.newClient()`
+|Both filters
+|===
+
+The first non-null source wins.
+The filter adds `Authorization: Bearer <token>` to the outbound request.
+
+=== Structural Validation
+
+When `@PropagateToken` captures a token, the LRA runtime validates that it has the
+three dot-separated segments expected of a JWS compact serialization
+(`header.payload.signature`).
+Tokens that fail this check are not propagated and a warning is logged.
+This catches misconfigured `Authorization` headers early without
+performing full JWT signature or claims validation (that remains the receiver's responsibility).
+
+[[recovery-thread-service-token]]
+== Recovery Thread and Service Token
+
+The Narayana recovery thread (`LRARecoveryModule.periodicWorkSecondPass()`) retries
+failed participant callbacks periodically.
+This thread runs outside of any CDI request scope, so `JsonWebToken` is not injectable.
+Without additional configuration, outbound calls from the recovery thread lack credentials
+and will be rejected by auth-protected participants.
+
+=== Symptom
+
+LRAs remain stuck in `Closing` or `Cancelling` state indefinitely.
+The coordinator log shows repeated retry attempts, while participant logs show HTTP 401 responses.
+
+=== Solution: Service Token
+
+The coordinator can read a pre-provisioned JWT from a file, classpath resource, or HTTP
+endpoint.
+When `JsonWebToken` is not available and a service token location is configured,
+`JwtTokenContext.newClient()` reads the token from that location and attaches it to
+outbound recovery requests.
+
+[source,properties]
+----
+lra.security.service-token.location=/var/run/secrets/lra/token
+lra.security.service-token.refresh-seconds=300
+----
+
+Supported location schemes:
+
+[cols="2,3,3",options="header"]
+|===
+|Scheme |Example |Use Case
+
+|Plain path
+|`/var/run/secrets/lra/token`
+|Kubernetes projected volumes or host filesystem
+
+|`file://`
+|`file:///opt/tokens/service.jwt`
+|Filesystem with explicit scheme
+
+|`classpath://`
+|`classpath://META-INF/service-token`
+|Bundled static token (development / testing)
+
+|`http://` or `https://`
+|`https://vault.example.com/v1/secret/lra-token`
+|Token vending service (5 s connect/read timeout, 64 KB limit)
+|===
+
+The token is cached for `lra.security.service-token.refresh-seconds` (default 300) and
+then re-read from the source.
+This supports external rotation: a sidecar, init container, or Vault Agent
+writes a fresh token to the file before the old one expires, and the coordinator picks
+it up on the next refresh cycle.
+
+=== Token Format and Issuance
+
+The service token is a standard MicroProfile JWT -- an RS256-signed JSON Web Token with
+at minimum the following claims:
+
+[cols="1,2",options="header"]
+|===
+|Claim |Description
+
+|`iss`
+|Issuer URI -- must match `mp.jwt.verify.issuer` on each participant
+
+|`sub`
+|Subject -- the coordinator's service identity (e.g. `lra-coordinator`)
+
+|`upn`
+|User principal name -- usually the same value as `sub`
+
+|`groups`
+|Array of role names -- must satisfy `@RolesAllowed` on participant callbacks if used
+
+|`exp`
+|Expiry -- set far enough in the future to span the token refresh interval
+|===
+
+[IMPORTANT]
+====
+The participants must be configured to trust the coordinator's service identity.
+The public key used to verify the token on the participant side must correspond to the
+private key used to sign the service token.
+The issuer (`iss`) claim must match the issuer configured for JWT verification on each participant.
+====
+
+The coordinator does *not* sign tokens itself.
+You are responsible for issuing and periodically rotating the service token using your
+identity infrastructure.
+Common approaches are described in the following subsections.
+
+==== Using an Identity Provider (Recommended)
+
+Identity providers such as Keycloak, HashiCorp Vault, or cloud IAM services can issue
+service tokens with configurable expiry and automatic rotation.
+
+.Keycloak example
+. Create a client (e.g., `lra-coordinator`) with client credentials grant.
+. Retrieve a token via the client credentials flow:
++
+[source,shell]
+----
+curl -s -X POST https://keycloak.example.com/realms/my-realm/protocol/openid-connect/token \
+  -d "grant_type=client_credentials" \
+  -d "client_id=lra-coordinator" \
+  -d "client_secret=<secret>" \
+  | jq -r .access_token > /var/run/secrets/lra/token
+----
+. Configure each participant with the Keycloak realm's public key and issuer URI:
++
+[source,properties]
+----
+mp.jwt.verify.publickey.location=https://keycloak.example.com/realms/my-realm/protocol/openid-connect/certs
+mp.jwt.verify.issuer=https://keycloak.example.com/realms/my-realm
+----
+
+A Kubernetes `CronJob` or a sidecar (e.g., `oauth2-proxy`, Vault Agent) can refresh
+the token file before it expires.
+
+==== Kubernetes Projected Volume (Short-Lived Tokens)
+
+When running in Kubernetes, use a projected service account token with an explicit audience:
+
+[source,yaml]
+----
+volumes:
+  - name: lra-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            audience: lra-participants
+            expirationSeconds: 3600
+            path: token
+----
+
+[source,yaml]
+----
+volumeMounts:
+  - name: lra-token
+    mountPath: /var/run/secrets/lra
+    readOnly: true
+----
+
+[source,properties]
+----
+lra.security.service-token.location=/var/run/secrets/lra/token
+lra.security.service-token.refresh-seconds=600
+----
+
+Each participant must accept the token by trusting the Kubernetes API server public key
+and the matching audience.
+Configure each participant's MicroProfile JWT to use the cluster's OIDC discovery endpoint:
+
+[source,properties]
+----
+mp.jwt.verify.publickey.location=https://kubernetes.default.svc/.well-known/openid-configuration
+mp.jwt.verify.issuer=https://kubernetes.default.svc
+----
+
+Kubernetes rotates projected tokens automatically before they expire, so no sidecar is needed.
+
+==== Generating a Static Token for Development
+
+For local development and testing you can generate a self-signed token with a tool such as
+`jose` (the https://github.com/go-jose/go-jose[go-jose] CLI) or a short Java program.
+The following illustrates the required structure -- *do not use a static token in production*:
+
+[source,shell]
+----
+# 1. Generate RSA key pair
+openssl genrsa -out coordinator-private.pem 2048
+openssl rsa -in coordinator-private.pem -pubout -out coordinator-public.pem
+
+# 2. Build header + payload
+HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
+PAYLOAD=$(echo -n '{
+  "iss":"lra-dev-issuer",
+  "sub":"lra-coordinator",
+  "upn":"lra-coordinator",
+  "groups":["lra-system"],
+  "exp":9999999999
+}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
+
+# 3. Sign and write the token
+echo -n "${HEADER}.${PAYLOAD}" \
+  | openssl dgst -sha256 -sign coordinator-private.pem \
+  | base64 -w0 | tr '+/' '-_' | tr -d '=' \
+  | read SIG; echo "${HEADER}.${PAYLOAD}.${SIG}" > /tmp/service-token
+----
+
+Configure each participant with `coordinator-public.pem` and the matching issuer:
+
+[source,properties]
+----
+mp.jwt.verify.publickey.location=META-INF/coordinator-public.pem
+mp.jwt.verify.issuer=lra-dev-issuer
+----
+
+[WARNING]
+====
+A static token with a far-future expiry cannot be revoked.
+Use this approach only in air-gapped development environments and never commit the
+private key or the token to source control.
+====
+
+=== Participant Trust Model
+
+When a service token is used, the coordinator authenticates to participants using its
+own service identity (not the original caller's identity).
+Participants must therefore trust the coordinator's service account to invoke
+compensate, complete, status, forget, and afterLRA callbacks on behalf of any caller.
+
+Design participant `@RolesAllowed` constraints accordingly:
+
+[source,java]
+----
+@Path("/order")
+public class OrderParticipant {
+
+    @PUT
+    @Path("/compensate")
+    @RolesAllowed({"lra-system", "user"})   // accepts both coordinator and user tokens
+    public Response compensate(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) { ... }
+}
+----
+
+== Logging
+
+Token resolution is logged at different levels to aid troubleshooting:
+
+[cols="1,3,3",options="header"]
+|===
+|Level |Message |Meaning
+
+|`TRACE`
+|"JWT token resolved from CDI JsonWebToken"
+|Token found via CDI lookup
+
+|`DEBUG`
+|"CDI not available for JWT resolution: ..."
+|CDI lookup failed (expected on recovery threads)
+
+|`INFO`
+|"Service token provider configured: location=..."
+|`ServiceTokenProvider` initialized at startup
+
+|`WARN`
+|"@PropagateToken: Authorization header does not contain a valid JWT structure"
+|Bearer token failed structural validation
+
+|`WARN`
+|"Failed to read service token from ..."
+|Service token file or HTTP endpoint could not be read
+|===
+
+== Testing
+
+JWT integration tests are in `test/security/` and run against WildFly via Arquillian
+(requires the `-Parq` Maven profile).
+
+[source,shell]
+----
+mvn verify -pl test/security -Parq
+----
+
+The tests verify:
+
+* *CDI injection*: `JsonWebToken` is resolvable and returns the raw token when a
+  valid Bearer token is provided
+* *Token validation*: tokens signed with the correct key are accepted; tokens with
+  a wrong issuer are rejected with HTTP 401
+
+Additional unit tests in `client/` verify:
+
+* *`@PropagateToken` flow*: annotation detection, token capture, structural validation,
+  filter propagation, and auto-registration via `RestClientConfig`
+* *Filter resolution order*: thread-local precedence over CDI and client property
+* *Structural JWT validation*: three-segment check accepts valid JWTs, rejects
+  malformed, opaque, and multi-segment tokens
+
+RSA key pairs are generated programmatically at test startup -- no PEM files are stored in the repository.
+
+== Configuration Reference
+
+[cols="3,1,3",options="header"]
+|===
+|Property |Default |Description
+
+|`lra.http-client.providers`
+|--
+|Comma-separated list of JAX-RS provider class names to register on outbound HTTP clients
+
+|`lra.security.service-token.location`
+|--
+|Location of the pre-provisioned service token used by the recovery thread
+(plain path, `file://`, `classpath://`, `http://`, or `https://`)
+
+|`lra.security.service-token.refresh-seconds`
+|`300`
+|How often the service token is re-read from its source (in seconds)
+|===

--- a/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -22,8 +22,10 @@ import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.MANDATORY;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type.NESTED;
 
 import io.narayana.lra.AnnotationResolver;
+import io.narayana.lra.BearerTokenResolver;
 import io.narayana.lra.Current;
 import io.narayana.lra.LRAConstants;
+import io.narayana.lra.PropagateToken;
 import io.narayana.lra.client.LRAParticipantData;
 import io.narayana.lra.client.NarayanaLRAClient;
 import io.narayana.lra.client.internal.proxy.nonjaxrs.LRAParticipant;
@@ -42,6 +44,7 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -139,6 +142,19 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
         if (transactional == null) {
             transactional = method.getDeclaringClass().getDeclaredAnnotation(LRA.class);
+        }
+
+        if (AnnotationResolver.isAnnotationPresent(PropagateToken.class, method)
+                || method.getDeclaringClass().isAnnotationPresent(PropagateToken.class)) {
+            String authHeader = containerRequestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
+            if (authHeader != null && authHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+                String token = authHeader.substring(7);
+                if (BearerTokenResolver.isPlausibleJwt(token)) {
+                    Current.setAuthToken(token);
+                } else {
+                    LRALogger.logger.warnf("@PropagateToken: Authorization header does not contain a valid JWT structure");
+                }
+            }
         }
 
         if (transactional != null) {
@@ -633,6 +649,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
             Current.popAll();
             Current.removeActiveLRACache(current);
+            Current.clearAuthToken();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,13 @@
     <version.microprofile-context-propagation-api>1.3</version.microprofile-context-propagation-api>
     <version.microprofile.config-api>3.1.1</version.microprofile.config-api>
     <version.microprofile.fault-tolerance>4.1.2</version.microprofile.fault-tolerance>
+    <version.microprofile.jwt>2.1</version.microprofile.jwt>
 
     <!-- Needed for WildflyLRACoordinatorDeployment class -->
     <version.microprofile.lra>2.0.2</version.microprofile.lra>
     <version.microprofile.rest-client-api>4.0</version.microprofile.rest-client-api>
-    <version.org.apache.activemq>2.55.0</version.org.apache.activemq>
+    <version.nimbus-jose-jwt>10.9</version.nimbus-jose-jwt>
+    <version.org.apache.activemq>2.53.0</version.org.apache.activemq>
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
     <version.org.eclipse.microprofile.openapi>4.1.1</version.org.eclipse.microprofile.openapi>
 
@@ -379,6 +381,11 @@
         <version>${version.microprofile.lra}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.microprofile.jwt</groupId>
+        <artifactId>microprofile-jwt-auth-api</artifactId>
+        <version>${version.microprofile.jwt}</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-api</artifactId>
         <version>${version.org.eclipse.microprofile.openapi}</version>
@@ -390,6 +397,12 @@
       </dependency>
 
       <!-- test dependencies -->
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>${version.nimbus-jose-jwt}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.jboss.byteman</groupId>
         <artifactId>byteman-bmunit5</artifactId>

--- a/service-base/pom.xml
+++ b/service-base/pom.xml
@@ -25,6 +25,16 @@
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- jboss logging -->
     <dependency>

--- a/service-base/src/main/java/io/narayana/lra/BearerTokenResolver.java
+++ b/service-base/src/main/java/io/narayana/lra/BearerTokenResolver.java
@@ -1,0 +1,96 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra;
+
+import io.narayana.lra.logging.LRALogger;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.client.ClientRequestContext;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * Resolves a JWT Bearer token from available sources for outbound HTTP calls.
+ *
+ * <p>
+ * Resolution order (first non-null wins):
+ * </p>
+ * <ol>
+ * <li>Thread-local token captured by {@link PropagateToken @PropagateToken}
+ * (only when {@code checkThreadLocal} is {@code true})</li>
+ * <li>{@link JsonWebToken} via CDI — available on request threads with an
+ * active MicroProfile JWT context</li>
+ * <li>Client configuration property {@value LRAConstants#BEARER_TOKEN_PROPERTY}
+ * — set at client creation time for async/recovery contexts</li>
+ * </ol>
+ */
+public final class BearerTokenResolver {
+
+    private BearerTokenResolver() {
+    }
+
+    /**
+     * Resolves a Bearer token from available sources.
+     *
+     * @param requestContext the outbound request context (for client property fallback)
+     * @param checkThreadLocal whether to check {@link Current#getAuthToken()} first
+     * @return the raw JWT token string, or {@code null} if none available
+     */
+    public static String resolve(ClientRequestContext requestContext, boolean checkThreadLocal) {
+        String token = null;
+
+        if (checkThreadLocal) {
+            token = Current.getAuthToken();
+        }
+
+        if (token == null) {
+            token = resolveFromCdi();
+        }
+
+        if (token == null) {
+            Object prop = requestContext.getConfiguration().getProperty(LRAConstants.BEARER_TOKEN_PROPERTY);
+            token = prop instanceof String ? (String) prop : null;
+        }
+
+        return token;
+    }
+
+    /**
+     * Attempts to resolve a JWT token from CDI.
+     *
+     * @return the raw token string, or {@code null} if CDI is unavailable or no token is resolvable
+     */
+    public static String resolveFromCdi() {
+        try {
+            Instance<JsonWebToken> jwt = CDI.current().select(JsonWebToken.class);
+            if (jwt.isResolvable()) {
+                String token = jwt.get().getRawToken();
+                if (token != null && LRALogger.logger.isTraceEnabled()) {
+                    LRALogger.logger.trace("JWT token resolved from CDI JsonWebToken");
+                }
+                return token;
+            }
+        } catch (IllegalStateException e) {
+            if (LRALogger.logger.isDebugEnabled()) {
+                LRALogger.logger.debugf("CDI not available for JWT resolution: %s", e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the token has the three dot-separated segments
+     * expected of a JWS compact serialization ({@code header.payload.signature}).
+     * Does not validate content or signature.
+     */
+    public static boolean isPlausibleJwt(String token) {
+        int firstDot = token.indexOf('.');
+        if (firstDot <= 0) {
+            return false;
+        }
+        int secondDot = token.indexOf('.', firstDot + 1);
+        return secondDot > firstDot + 1 && token.indexOf('.', secondDot + 1) == -1;
+    }
+}

--- a/service-base/src/main/java/io/narayana/lra/Current.java
+++ b/service-base/src/main/java/io/narayana/lra/Current.java
@@ -38,6 +38,20 @@ public class Current {
      */
     private static final Map<URI, Integer> activeLRACache = new ConcurrentHashMap<>();
 
+    private static final ThreadLocal<String> authToken = new ThreadLocal<>();
+
+    public static void setAuthToken(String token) {
+        authToken.set(token);
+    }
+
+    public static String getAuthToken() {
+        return authToken.get();
+    }
+
+    public static void clearAuthToken() {
+        authToken.remove();
+    }
+
     @SuppressWarnings("ConstantConditions")
     public static void addActiveLRACache(URI lraId) {
         if (lraId == null) {

--- a/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -85,6 +85,12 @@ public final class LRAConstants {
     public static final long PARTICIPANT_TIMEOUT = 2;
     public static final String ALLOW_PARTICIPANT_DATA = "lra.participant.data";
 
+    public static final String HTTP_CLIENT_PROVIDERS = "lra.http-client.providers";
+    public static final String BEARER_TOKEN_PROPERTY = "lra.jwt.token";
+
+    public static final String SERVICE_TOKEN_LOCATION = "lra.security.service-token.location";
+    public static final String SERVICE_TOKEN_REFRESH_SECONDS = "lra.security.service-token.refresh-seconds";
+
     /**
      * Number of milliseconds for the coordinator to hold a lock for enlisting participants. Defaults to 500.
      */

--- a/service-base/src/main/java/io/narayana/lra/PropagateToken.java
+++ b/service-base/src/main/java/io/narayana/lra/PropagateToken.java
@@ -1,0 +1,36 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the inbound JWT Bearer token should be propagated on outbound
+ * LRA coordinator calls made during this method's execution.
+ *
+ * <p>
+ * Place on a resource method alongside {@code @LRA} to enable automatic
+ * token propagation without configuring {@code lra.http-client.providers}:
+ * </p>
+ *
+ * <pre>
+ * &#64;LRA(value = LRA.Type.REQUIRED)
+ * &#64;PropagateToken
+ * &#64;GET
+ * public Response startWork() { ... }
+ * </pre>
+ *
+ * <p>
+ * Can also be placed on the class to apply to all {@code @LRA} methods.
+ * </p>
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PropagateToken {
+}

--- a/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
+++ b/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
@@ -186,6 +186,13 @@ public interface LraI18nLogger {
             " balancer method `%s` is unsupported")
     String error_unsupportedLoadBalancer(String requestedMethod);
 
+    @LogMessage(level = WARN)
+    @Message(id = 25049, value = "Failed to read service token from '%s': %s")
+    void warn_failedToReadServiceToken(String location, String reason, @Cause Throwable t);
+
+    @Message(id = 25050, value = "Service token provider configured: location=%s, refresh=%ds")
+    String info_serviceTokenProviderConfigured(String location, long refreshSeconds);
+
     /*
      * Allocate new messages directly above this notice.
      * - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,6 +21,7 @@
   <modules>
     <module>tck</module>
     <module>basic</module>
+    <module>security</module>
   </modules>
 
   <properties>

--- a/test/security/pom.xml
+++ b/test/security/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jboss.narayana.lra</groupId>
+    <artifactId>lra-test</artifactId>
+    <version>2.0.0.Final-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>lra-test-security</artifactId>
+  <name>LRA tests: Security</name>
+  <description>Integration tests for JWT authentication, token propagation, and role-based access control</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>narayana-lra</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>lra-service-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>lra-test-arquillian-extension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/test/security/src/test/java/io/narayana/lra/arquillian/Deployer.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/Deployer.java
@@ -1,0 +1,74 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class Deployer {
+
+    public static final String TEST_ISSUER = "lra-test-issuer";
+
+    public static WebArchive deploy(String appName, Class... participants) {
+        try {
+            TestKeyManager.generateKeyPair();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate test key pair", e);
+        }
+        final String ManifestMF = "Manifest-Version: 1.0\n"
+                + "Dependencies: org.jboss.jandex, org.jboss.logging, org.eclipse.microprofile.jwt.auth.api\n";
+
+        final String mpJwtConfig = "mp.jwt.verify.publickey.location=META-INF/test-public-key.pem\n"
+                + "mp.jwt.verify.issuer=" + TEST_ISSUER + "\n";
+
+        return ShrinkWrap.create(WebArchive.class, appName + ".war")
+                .addPackages(true,
+                        "org.eclipse.microprofile.lra",
+                        "io.narayana.lra.client.internal.proxy",
+                        "io.smallrye.stork",
+                        "io.smallrye.mutiny")
+                .addPackages(false,
+                        "io.narayana.lra",
+                        "io.narayana.lra.logging",
+                        "io.narayana.lra.filter",
+                        "io.narayana.lra.provider",
+                        "io.narayana.lra.context",
+                        "io.narayana.lra.client",
+                        "io.narayana.lra.client.internal",
+                        "io.narayana.lra.arquillian.spi",
+                        "io.smallrye.stork",
+                        "io.smallrye.mutiny",
+                        "io.smallrye.mutiny.helpers",
+                        "io.smallrye.mutiny.operators.multi",
+                        "io.smallrye.mutiny.subscription",
+                        "io.smallrye.mutiny.helpers.spies",
+                        "io.smallrye.mutiny.helpers.test")
+                .addClass(TestBase.class)
+                .addClass(io.narayana.lra.arquillian.resource.JwtTestApplication.class)
+                .addClasses(participants)
+                .addAsManifestResource(new StringAsset(ManifestMF), "MANIFEST.MF")
+                .addAsWebInfResource(new StringAsset("<beans version=\"1.1\" bean-discovery-mode=\"all\"></beans>"),
+                        "beans.xml")
+                .addAsWebInfResource(new StringAsset(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                                + "<web-app xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" version=\"6.0\">\n"
+                                + "  <context-param>\n"
+                                + "    <param-name>resteasy.role.based.security</param-name>\n"
+                                + "    <param-value>true</param-value>\n"
+                                + "  </context-param>\n"
+                                + "</web-app>\n"),
+                        "web.xml")
+                .addAsResource(new StringAsset("org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder"),
+                        "META-INF/services/jakarta.ws.rs.client.ClientBuilder")
+                .addAsResource(new StringAsset("io.narayana.lra.context.ClientLRAContextProviderEE"),
+                        "META-INF/services/jakarta.enterprise.concurrent.spi.ThreadContextProvider")
+
+                // MP JWT configuration with runtime-generated public key
+                .addAsResource(new StringAsset(mpJwtConfig), "META-INF/microprofile-config.properties")
+                .addAsResource(new StringAsset(TestKeyManager.getPublicKeyPem()), "META-INF/test-public-key.pem");
+    }
+}

--- a/test/security/src/test/java/io/narayana/lra/arquillian/JwtCdiIntegrationIT.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/JwtCdiIntegrationIT.java
@@ -1,0 +1,128 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.narayana.lra.arquillian.resource.JwtParticipant;
+import jakarta.ws.rs.core.Response;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.logging.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+/**
+ * Integration tests verifying JWT CDI integration: that the container's MP JWT
+ * implementation makes {@code JsonWebToken} available via CDI, validates token
+ * signatures, and enforces issuer claims.
+ *
+ * <p>
+ * Requires the {@code -Parq} Maven profile to start WildFly containers.
+ */
+public class JwtCdiIntegrationIT extends TestBase {
+
+    private static final Logger log = Logger.getLogger(JwtCdiIntegrationIT.class.getName());
+
+    @ArquillianResource
+    public URL baseURL;
+
+    private String testName;
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(JwtCdiIntegrationIT.class.getSimpleName(), JwtParticipant.class);
+    }
+
+    @BeforeAll
+    public static void setupKeys() throws Exception {
+        TestKeyManager.generateKeyPair();
+    }
+
+    @BeforeEach
+    public void before(TestInfo testInfo) {
+        testName = testInfo.getDisplayName();
+        log.info("Running test " + testName);
+    }
+
+    @Test
+    public void testJsonWebTokenInjectionIsResolvableWithoutToken() {
+        try (Response response = client.target(baseURL.toExternalForm())
+                .path(JwtParticipant.ROOT_PATH)
+                .path(JwtParticipant.CDI_TOKEN_PATH)
+                .request()
+                .get()) {
+            assertEquals(200, response.getStatus(),
+                    "CDI Instance<JsonWebToken> should not cause deployment or request failure");
+            String rawToken = response.readEntity(String.class);
+            assertTrue(rawToken.isEmpty(),
+                    "Without a Bearer token in the request, getRawToken() should return null/empty");
+        }
+    }
+
+    @Test
+    public void testJsonWebTokenReturnsSignedToken() throws Exception {
+        String token = TestKeyManager.createSignedToken("test-user", "user");
+
+        try (Response response = client.target(baseURL.toExternalForm())
+                .path(JwtParticipant.ROOT_PATH)
+                .path(JwtParticipant.CDI_TOKEN_PATH)
+                .request()
+                .header("Authorization", "Bearer " + token)
+                .get()) {
+            assertEquals(200, response.getStatus());
+            String rawToken = response.readEntity(String.class);
+            assertFalse(rawToken.isEmpty(),
+                    "With a valid signed Bearer token, JsonWebToken.getRawToken() should return it");
+            assertEquals(token, rawToken);
+        }
+    }
+
+    @Test
+    public void testWrongIssuerTokenIsNotAccepted() throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer("wrong-issuer")
+                .subject("test-user")
+                .claim("upn", "test-user")
+                .claim("groups", Arrays.asList("user"))
+                .issueTime(new Date())
+                .expirationTime(new Date(System.currentTimeMillis() + 600_000))
+                .build();
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(TestKeyManager.getRsaKey().getKeyID())
+                .type(com.nimbusds.jose.JOSEObjectType.JWT)
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        signedJWT.sign(new RSASSASigner(TestKeyManager.getRsaKey()));
+
+        String badToken = signedJWT.serialize();
+
+        try (Response response = client.target(baseURL.toExternalForm())
+                .path(JwtParticipant.ROOT_PATH)
+                .path(JwtParticipant.CDI_TOKEN_PATH)
+                .request()
+                .header("Authorization", "Bearer " + badToken)
+                .get()) {
+            assertEquals(401, response.getStatus(),
+                    "Token with wrong issuer should be rejected by the MP JWT runtime");
+        }
+    }
+}

--- a/test/security/src/test/java/io/narayana/lra/arquillian/TestBase.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/TestBase.java
@@ -1,0 +1,58 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import io.narayana.lra.LRAData;
+import io.narayana.lra.client.NarayanaLRAClient;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@RunAsClient
+@ExtendWith(ArquillianExtension.class)
+public abstract class TestBase {
+
+    public static NarayanaLRAClient lraClient;
+    public static String coordinatorUrl;
+    public static Client client;
+    public static List<URI> lrasToAfterFinish;
+
+    @BeforeAll
+    public static void beforeClass() {
+        lraClient = new NarayanaLRAClient();
+        coordinatorUrl = lraClient.getCoordinatorUrl();
+        client = ClientBuilder.newClient();
+        lrasToAfterFinish = new ArrayList<>();
+    }
+
+    @AfterEach
+    public void after() {
+        List<URI> lraURIList = lraClient.getAllLRAs().stream().map(LRAData::getLraId).collect(Collectors.toList());
+        if (lrasToAfterFinish != null) {
+            for (URI lraToFinish : lrasToAfterFinish) {
+                if (lraURIList.contains(lraToFinish)) {
+                    lraClient.cancelLRA(lraToFinish);
+                }
+            }
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (client != null) {
+            client.close();
+        }
+    }
+}

--- a/test/security/src/test/java/io/narayana/lra/arquillian/TestKeyManager.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/TestKeyManager.java
@@ -1,0 +1,76 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+public final class TestKeyManager {
+
+    private static volatile RSAKey rsaKey;
+
+    private TestKeyManager() {
+    }
+
+    public static synchronized void generateKeyPair() throws Exception {
+        if (rsaKey != null) {
+            return;
+        }
+        rsaKey = new RSAKeyGenerator(2048)
+                .keyID("test-key-id")
+                .generate();
+    }
+
+    public static String getPublicKeyPem() {
+        try {
+            RSAPublicKey publicKey = rsaKey.toRSAPublicKey();
+            byte[] encoded = publicKey.getEncoded();
+            return "-----BEGIN PUBLIC KEY-----\n"
+                    + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(encoded)
+                    + "\n-----END PUBLIC KEY-----\n";
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to export public key as PEM", e);
+        }
+    }
+
+    public static String createSignedToken(String subject, String... groups) throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(Deployer.TEST_ISSUER)
+                .subject(subject)
+                .claim("upn", subject)
+                .claim("groups", Arrays.asList(groups))
+                .jwtID(UUID.randomUUID().toString())
+                .issueTime(new Date())
+                .expirationTime(new Date(System.currentTimeMillis() + 600_000))
+                .build();
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(rsaKey.getKeyID())
+                .type(com.nimbusds.jose.JOSEObjectType.JWT)
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        JWSSigner signer = new RSASSASigner(rsaKey);
+        signedJWT.sign(signer);
+
+        return signedJWT.serialize();
+    }
+
+    public static RSAKey getRsaKey() {
+        return rsaKey;
+    }
+}

--- a/test/security/src/test/java/io/narayana/lra/arquillian/resource/JwtParticipant.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/resource/JwtParticipant.java
@@ -1,0 +1,88 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+
+/**
+ * A participant that captures the JWT token it receives from the coordinator
+ * during compensate/complete callbacks, making it available for test assertions.
+ *
+ * <p>
+ * Also exposes the CDI-injected {@link JsonWebToken} to verify that the
+ * container's MP JWT implementation is active and working.
+ */
+@ApplicationScoped
+@Path(JwtParticipant.ROOT_PATH)
+public class JwtParticipant {
+    public static final String ROOT_PATH = "jwt-participant";
+    public static final String START_LRA_PATH = "start-lra";
+    public static final String CDI_TOKEN_PATH = "cdi-token";
+    public static final String LAST_CALLBACK_AUTH_PATH = "last-callback-auth";
+    @Inject
+    Instance<JsonWebToken> jwtTokenInstance;
+
+    private static volatile String lastCallbackAuthHeader;
+
+    @GET
+    @Path(START_LRA_PATH)
+    @LRA(value = LRA.Type.REQUIRED)
+    public Response startLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.ok(lraId.toASCIIString()).build();
+    }
+
+    @GET
+    @Path(CDI_TOKEN_PATH)
+    public Response getCdiToken() {
+        String rawToken = null;
+        if (jwtTokenInstance.isResolvable()) {
+            rawToken = jwtTokenInstance.get().getRawToken();
+        }
+        return Response.ok(rawToken != null ? rawToken : "").build();
+    }
+
+    @GET
+    @Path(LAST_CALLBACK_AUTH_PATH)
+    public Response getLastCallbackAuth() {
+        return Response.ok(lastCallbackAuthHeader != null ? lastCallbackAuthHeader : "").build();
+    }
+
+    @PUT
+    @Path("/compensate")
+    @Compensate
+    public Response compensate(
+            @HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
+            @HeaderParam(HttpHeaders.AUTHORIZATION) String authHeader) {
+        lastCallbackAuthHeader = authHeader;
+        return Response.ok(ParticipantStatus.Compensated.name()).build();
+    }
+
+    @PUT
+    @Path("/complete")
+    @Complete
+    public Response complete(
+            @HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
+            @HeaderParam(HttpHeaders.AUTHORIZATION) String authHeader) {
+        lastCallbackAuthHeader = authHeader;
+        return Response.ok(ParticipantStatus.Completed.name()).build();
+    }
+}

--- a/test/security/src/test/java/io/narayana/lra/arquillian/resource/JwtTestApplication.java
+++ b/test/security/src/test/java/io/narayana/lra/arquillian/resource/JwtTestApplication.java
@@ -1,0 +1,15 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import org.eclipse.microprofile.auth.LoginConfig;
+
+@ApplicationPath("/")
+@LoginConfig(authMethod = "MP-JWT")
+public class JwtTestApplication extends Application {
+}

--- a/test/security/src/test/resources/arquillian-wildfly.xml
+++ b/test/security/src/test/resources/arquillian-wildfly.xml
@@ -1,0 +1,23 @@
+<!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+ -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="${arquillian.lra.participant.container.qualifier}" mode="suite" default="true">
+        <configuration>
+            <property name="jbossHome">${wildfly.home}</property>
+            <property name="javaVmArguments">${server.jvm.args} ${lra.participant.debug.params} -Dlra.coordinator.url=${lra.coordinator.url} -Djboss.socket.binding.port-offset=100</property>
+            <property name="managementAddress">${test.application.host}</property>
+            <property name="managementPort">10090</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
+            <property name="serverConfig">${lra.participant.xml.filename}</property>
+        </configuration>
+    </container>
+
+    <extension qualifier="Deployer"/>
+</arquillian>

--- a/test/security/src/test/resources/logging.properties
+++ b/test/security/src/test/resources/logging.properties
@@ -1,0 +1,12 @@
+#
+# SPDX short identifier: Apache-2.0
+#
+
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = INFO
+# settings the console formatter
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %4$s: [%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS] [%2$s] %5$s%n
+
+.level = INFO
+org.jboss.weld.level = INFO

--- a/test/tck/pom.xml
+++ b/test/tck/pom.xml
@@ -53,6 +53,11 @@
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.jwt</groupId>
+      <artifactId>microprofile-jwt-auth-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
addresses https://github.com/jbosstm/lra/issues/314

When JWT is enabled:
 
- Inbound auth: JwtAuthFilter validates Bearer tokens on coordinator endpoints using RSA public key verification with issuer/audience  checks, returning 401 on failure.                                                                                                       
- Token capture: JwtTokenRequestFilter extracts the inbound token and stores it in LRABearerToken (thread-local), making it available  for outbound calls to participants.                                                                                                     
- Outbound propagation: JwtTokenClientRequestFilter re-attaches the captured token to outgoing REST client requests so              coordinator-to-participant calls are authenticated.                                                                                     
- Recovery support: ServiceTokenProvider supplies tokens for async recovery threads (no inbound request context) via file, classpath, or  HTTP sources with configurable refresh.  

cc @arjantijms 

https://github.com/jbosstm/jboss-as/pull/102