### PR TITLE
Downgrade resteasy to 6.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <version.org.jboss.logging.jboss-logging>3.6.3.Final</version.org.jboss.logging.jboss-logging>
     <version.org.jboss.logging.jboss-logging-processor>3.0.4.Final</version.org.jboss.logging.jboss-logging-processor>
     <!-- Needed for WildflyLRACoordinatorDeployment class -->
-    <version.org.jboss.resteasy>7.0.1.Final</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>6.2.16.Final</version.org.jboss.resteasy>
     <version.org.jboss.resteasy.microprofile>3.0.1.Final</version.org.jboss.resteasy.microprofile>
     <version.org.jboss.shrinkwrap.resolvers>3.3.5</version.org.jboss.shrinkwrap.resolvers>
     <version.org.sonatype.plugins.nxrm3.plugin>1.0.13</version.org.sonatype.plugins.nxrm3.plugin>


### PR DESCRIPTION
As discussed at https://github.com/jbosstm/lra/pull/315 we want to be aligned with Quarkus and WildFly using resteasy 6.2.x until we stick with Jakarta EE 10
see https://jakarta.ee/release/10/#:~:text=Jakarta%20EE%2010%20delivers%20noteworthy,Security%203.0%20supporting%20OpenID%20Connect
