### PR TITLE
microprofile-lra forget method MUST be  * {@link jakarta.ws.rs.DELETE}

### DIFF
--- a/client/src/main/java/io/narayana/lra/client/CoordinatorClient.java
+++ b/client/src/main/java/io/narayana/lra/client/CoordinatorClient.java
@@ -7,6 +7,7 @@ package io.narayana.lra.client;
 
 import io.narayana.lra.LRAConstants;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -250,7 +251,7 @@ public interface CoordinatorClient {
      * @param nestedLraId Nested LRA identifier
      * @return Response indicating success
      */
-    @PUT
+    @DELETE
     @Path("nested/{NestedLraId}/forget")
     CompletionStage<Response> forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId);
 }

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -39,6 +39,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -440,7 +441,7 @@ public class Coordinator extends Application {
         return buildResponse(mapToParticipantStatus(lraData.getStatus()).name(), version, mediaType);
     }
 
-    @PUT
+    @DELETE
     @Path("nested/{NestedLraId}/forget")
     public Response forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         lraService.remove(toURI(nestedLraId));


### PR DESCRIPTION
As per the spec: https://github.com/microprofile/microprofile-lra/blob/main/api/src/main/java/org/eclipse/microprofile/lra/annotation/Forget.java#L46-L47

"If the [Forget] annotation is applied to a JAX-RS resource method then the request method MUST be * {@link jakarta.ws.rs.DELETE}"