### PR TITLE
Extract Nested Endpoints into NestedCoordinator Sub-Resource

### DIFF
--- a/client/src/main/java/io/narayana/lra/client/CoordinatorClient.java
+++ b/client/src/main/java/io/narayana/lra/client/CoordinatorClient.java
@@ -7,6 +7,7 @@ package io.narayana.lra.client;
 
 import io.narayana.lra.LRAConstants;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -250,7 +251,7 @@ public interface CoordinatorClient {
      * @param nestedLraId Nested LRA identifier
      * @return Response indicating success
      */
-    @PUT
+    @DELETE
     @Path("nested/{NestedLraId}/forget")
     CompletionStage<Response> forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId);
 }

--- a/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -885,14 +885,16 @@ public class NarayanaLRAClient implements Closeable {
     public ParticipantStatus getNestedLRAStatus(URI nestedLraId)
             throws WebApplicationException {
         try {
-
             URI uriWithoutQuery = UriBuilder.fromUri(nestedLraId).replaceQuery(null).build();
             CoordinatorClient client = createCoordinatorClient(LRAConstants.getLRACoordinatorUrl(uriWithoutQuery));
 
-            // ParentLRA query is part of the lra id, so keeping it
             String encodedLRA = URLEncoder.encode(nestedLraId.toString(), StandardCharsets.UTF_8);
             Response response = client.getNestedLRAStatus(encodedLRA)
                     .toCompletableFuture().get(QUERY_TIMEOUT, TimeUnit.SECONDS);
+
+            if (response.getStatus() == Response.Status.GONE.getStatusCode()) {
+                throw new NotFoundException("Nested LRA is no longer known: " + nestedLraId);
+            }
 
             if (response.getStatus() != OK.getStatusCode()) {
                 throw new WebApplicationException(response);
@@ -928,7 +930,6 @@ public class NarayanaLRAClient implements Closeable {
             URI uriWithoutQuery = UriBuilder.fromUri(nestedLraId).replaceQuery(null).build();
             CoordinatorClient client = createCoordinatorClient(LRAConstants.getLRACoordinatorUrl(uriWithoutQuery));
 
-            // Extract the LRA UID
             String encodedLRA = URLEncoder.encode(nestedLraId.toString(), StandardCharsets.UTF_8);
             Response response = client.completeNestedLRA(
                     encodedLRA,
@@ -936,18 +937,7 @@ public class NarayanaLRAClient implements Closeable {
                     LRAConstants.CURRENT_API_VERSION_STRING)
                     .toCompletableFuture().get(END_TIMEOUT, TimeUnit.SECONDS);
 
-            if (response.getStatus() != OK.getStatusCode()) {
-                throw new WebApplicationException(response);
-            }
-
-            if (!response.hasEntity()) {
-                throw new WebApplicationException(
-                        Response.status(INTERNAL_SERVER_ERROR)
-                                .entity("No status returned for nested LRA completion").build());
-            }
-
-            String statusString = response.readEntity(String.class);
-            return ParticipantStatus.valueOf(statusString);
+            return handleNestedEndResponse(response, nestedLraId, "completion");
         } catch (ExecutionException e) {
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
@@ -977,24 +967,36 @@ public class NarayanaLRAClient implements Closeable {
                     LRAConstants.CURRENT_API_VERSION_STRING)
                     .toCompletableFuture().get(END_TIMEOUT, TimeUnit.SECONDS);
 
-            if (response.getStatus() != OK.getStatusCode()) {
-                throw new WebApplicationException(response);
-            }
-
-            if (!response.hasEntity()) {
-                throw new WebApplicationException(
-                        Response.status(INTERNAL_SERVER_ERROR)
-                                .entity("No status returned for nested LRA compensation").build());
-            }
-
-            String statusString = response.readEntity(String.class);
-            return ParticipantStatus.valueOf(statusString);
+            return handleNestedEndResponse(response, nestedLraId, "compensation");
         } catch (ExecutionException e) {
             throw new NotFoundException(e.getMessage());
         } catch (InterruptedException | TimeoutException e) {
             throw new WebApplicationException(Response.status(SERVICE_UNAVAILABLE)
                     .entity("compensate nested LRA client request timed out, try again later").build());
         }
+    }
+
+    private ParticipantStatus handleNestedEndResponse(Response response, URI nestedLraId, String operation) {
+        int status = response.getStatus();
+
+        if (status == Response.Status.GONE.getStatusCode()) {
+            throw new NotFoundException("Nested LRA is no longer known: " + nestedLraId);
+        }
+
+        if (status != OK.getStatusCode()
+                && status != Response.Status.ACCEPTED.getStatusCode()
+                && status != Response.Status.CONFLICT.getStatusCode()) {
+            throw new WebApplicationException(response);
+        }
+
+        if (!response.hasEntity()) {
+            throw new WebApplicationException(
+                    Response.status(INTERNAL_SERVER_ERROR)
+                            .entity("No status returned for nested LRA " + operation).build());
+        }
+
+        String statusString = response.readEntity(String.class);
+        return ParticipantStatus.valueOf(statusString);
     }
 
     /**
@@ -1013,7 +1015,8 @@ public class NarayanaLRAClient implements Closeable {
             Response response = client.forgetNestedLRA(encodedLRA)
                     .toCompletableFuture().get(END_TIMEOUT, TimeUnit.SECONDS);
 
-            if (response.getStatus() != OK.getStatusCode()) {
+            int status = response.getStatus();
+            if (status != OK.getStatusCode() && status != Response.Status.GONE.getStatusCode()) {
                 throw new WebApplicationException(response);
             }
         } catch (ExecutionException e) {

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -75,7 +75,6 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
-import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 import org.eclipse.microprofile.openapi.annotations.Components;
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -111,15 +110,22 @@ public class Coordinator extends Application {
 
     private final LRAService lraService;
     private final RecoveryCoordinator recoveryCoordinator;
+    private final NestedCoordinator nestedCoordinator;
 
     public Coordinator() {
         lraService = LRARecoveryModule.getService();
         recoveryCoordinator = new RecoveryCoordinator();
+        nestedCoordinator = new NestedCoordinator();
     }
 
     @Path(RECOVERY_COORDINATOR_PATH_NAME)
     public RecoveryCoordinator getRecoveryCoordinator() {
         return recoveryCoordinator;
+    }
+
+    @Path(LRAConstants.NESTED_COORDINATOR_PATH_NAME)
+    public NestedCoordinator getNestedCoordinator() {
+        return nestedCoordinator;
     }
 
     private static boolean initAllowParticipantData() {
@@ -295,7 +301,8 @@ public class Coordinator extends Application {
 
         if (parentId != null) {
             // the startLRA call will have imported the parent LRA
-            String compensatorUrl = String.format("%s/nested/%s", coordinatorUrl, LRAConstants.getLRAUid(lraId));
+            String compensatorUrl = String.format("%s/%s/%s", coordinatorUrl, LRAConstants.NESTED_COORDINATOR_PATH_NAME,
+                    LRAConstants.getLRAUid(lraId));
 
             if (!lraService.hasTransaction(parentId)) {
 
@@ -366,90 +373,6 @@ public class Coordinator extends Application {
                 .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
                 .entity(lraId)
                 .build();
-    }
-
-    @GET
-    @Path("nested/{NestedLraId}/status")
-    public Response getNestedLRAStatus(@PathParam("NestedLraId") String nestedLraId) {
-        // needed to decode string passed from clients
-        String decodedURL = URLDecoder.decode(nestedLraId, StandardCharsets.UTF_8);
-        if (!lraService.hasTransaction(decodedURL)) {
-            // it must have compensated
-            return Response.ok(ParticipantStatus.Compensated.name()).build();
-        }
-
-        LongRunningAction lra = lraService.getTransaction(toURI(nestedLraId));
-        LRAStatus status = lra.getLRAStatus();
-
-        if (status == null || lra.getLRAStatus() == null) {
-            String errMsg = LRALogger.i18nLogger.error_cannotGetStatusOfNestedLraURI(nestedLraId, lra.getId());
-            LRALogger.logger.debug(errMsg);
-            throw new WebApplicationException(errMsg, Response.status(PRECONDITION_FAILED)
-                    .entity(errMsg)
-                    .build());
-        }
-
-        return Response.ok(mapToParticipantStatus(lra.getLRAStatus()).name()).build();
-    }
-
-    private ParticipantStatus mapToParticipantStatus(LRAStatus lraStatus) {
-        switch (lraStatus) {
-            case Active:
-                return ParticipantStatus.Active;
-            case Closed:
-                return ParticipantStatus.Completed;
-            case Cancelled:
-                return ParticipantStatus.Compensated;
-            case Closing:
-                return ParticipantStatus.Completing;
-            case Cancelling:
-                return ParticipantStatus.Compensating;
-            case FailedToClose:
-                return ParticipantStatus.FailedToComplete;
-            case FailedToCancel:
-                return ParticipantStatus.FailedToCompensate;
-            default:
-                // the status has been provided by a nested coordinator which we don't necessarily control
-                // - it's not a client error but a problem with the remote server so we have no other option
-                // than to report it as an internal error:
-                String errMsg = LRALogger.i18nLogger.warn_invalid_lraStatus(String.valueOf(lraStatus));
-                LRALogger.logger.debug(errMsg);
-                throw new WebApplicationException(errMsg, Response.status(INTERNAL_SERVER_ERROR)
-                        .entity(errMsg)
-                        .build());
-        }
-    }
-
-    @PUT
-    @Path("nested/{NestedLraId}/complete")
-    public Response completeNestedLRA(
-            @PathParam("NestedLraId") String nestedLraId,
-            @HeaderParam(HttpHeaders.ACCEPT) @DefaultValue(MediaType.TEXT_PLAIN) String mediaType,
-            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
-
-        LRAData lraData = lraService.endLRA(toURI(nestedLraId), false, false, null, null);
-
-        return buildNestedResponse(mapToParticipantStatus(lraData.getStatus()).name(), version, mediaType);
-    }
-
-    @PUT
-    @Path("nested/{NestedLraId}/compensate")
-    public Response compensateNestedLRA(
-            @PathParam("NestedLraId") String nestedLraId,
-            @HeaderParam(HttpHeaders.ACCEPT) @DefaultValue(MediaType.TEXT_PLAIN) String mediaType,
-            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
-
-        LRAData lraData = lraService.endLRA(toURI(nestedLraId), true, true, null, null);
-
-        return buildNestedResponse(mapToParticipantStatus(lraData.getStatus()).name(), version, mediaType);
-    }
-
-    @PUT
-    @Path("nested/{NestedLraId}/forget")
-    public Response forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
-        lraService.remove(toURI(nestedLraId));
-
-        return Response.ok().build();
     }
 
     /**
@@ -793,26 +716,6 @@ public class Coordinator extends Application {
             return builder.entity(model.toString()).build();
         } else { // produce MediaType.TEXT_PLAIN
             return builder.entity(statusName).build();
-        }
-    }
-
-    /**
-     * Build a response for nested LRA endpoints that return ParticipantStatus names.
-     * Nested endpoints always return 200 since they report participant-level status.
-     */
-    private Response buildNestedResponse(String status, String apiVersion, String mediaType) {
-        if (mediaType.equals(MediaType.APPLICATION_JSON)) {
-            JsonObject model = Json.createObjectBuilder()
-                    .add("status", status)
-                    .build();
-
-            return Response.ok(model.toString())
-                    .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, apiVersion)
-                    .build();
-        } else {
-            return Response.ok(status)
-                    .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, apiVersion)
-                    .build();
         }
     }
 

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -8,6 +8,7 @@ package io.narayana.lra.coordinator.api;
 import static io.narayana.lra.LRAConstants.API_VERSION_1_0;
 import static io.narayana.lra.LRAConstants.API_VERSION_1_1;
 import static io.narayana.lra.LRAConstants.API_VERSION_1_2;
+import static io.narayana.lra.LRAConstants.API_VERSION_1_3;
 import static io.narayana.lra.LRAConstants.CLIENT_ID_PARAM_NAME;
 import static io.narayana.lra.LRAConstants.COMPENSATE;
 import static io.narayana.lra.LRAConstants.COMPLETE;
@@ -736,7 +737,8 @@ public class Coordinator extends Application {
         return version != null
                 && !version.equals(API_VERSION_1_0)
                 && !version.equals(API_VERSION_1_1)
-                && !version.equals(API_VERSION_1_2);
+                && !version.equals(API_VERSION_1_2)
+                && !version.equals(API_VERSION_1_3);
     }
 
     private URI toURI(String lraId) {

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/NestedCoordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/NestedCoordinator.java
@@ -1,0 +1,271 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.narayana.lra.coordinator.api;
+
+import static io.narayana.lra.LRAConstants.COORDINATOR_PATH_NAME;
+import static io.narayana.lra.LRAConstants.CURRENT_API_VERSION_STRING;
+import static io.narayana.lra.LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.LRAData;
+import io.narayana.lra.coordinator.domain.service.LRAService;
+import io.narayana.lra.coordinator.internal.LRARecoveryModule;
+import io.narayana.lra.logging.LRALogger;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.headers.Header;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Tag(name = "Nested LRA Participant", description = "Implements the MicroProfile LRA participant contract (@Complete, @Compensate, @Status, @Forget)"
+        + " for nested LRAs. These endpoints are called by the parent LRA coordinator.")
+public class NestedCoordinator {
+    private final LRAService lraService;
+
+    public NestedCoordinator() {
+        lraService = LRARecoveryModule.getService();
+    }
+
+    @GET
+    @Path("{NestedLraId}/status")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Operation(summary = "Get the status of a nested LRA participant", description = "Implements the @Status participant contract as defined by the MicroProfile LRA specification."
+            + " Returns the current ParticipantStatus of the nested LRA.")
+    @APIResponses({
+            @APIResponse(responseCode = "200", description = "The current ParticipantStatus is available."
+                    + " The caller must inspect the body to determine whether the participant"
+                    + " has reached a terminal state.", content = @Content(schema = @Schema(implementation = String.class))),
+            @APIResponse(responseCode = "410", description = "The participant is no longer aware of this LRA.", content = @Content(schema = @Schema(implementation = String.class))),
+    })
+    public Response getNestedLRAStatus(
+            @PathParam("NestedLraId") String nestedLraId,
+            @Context UriInfo uriInfo) {
+        try {
+            LRAStatus status = lraService.getTransaction(toURI(nestedLraId, uriInfo)).getLRAStatus();
+
+            if (status == null) {
+                throw new WebApplicationException(
+                        LRALogger.i18nLogger.error_cannotGetStatusOfNestedLraURI(nestedLraId, null),
+                        Response.status(INTERNAL_SERVER_ERROR).build());
+            }
+
+            return Response.ok(mapToParticipantStatus(status).name()).build();
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.GONE).build();
+        }
+    }
+
+    @PUT
+    @Path("{NestedLraId}/complete")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Operation(summary = "Complete a nested LRA", description = "Implements the @Complete participant contract"
+            + " for a nested LRA as defined by the MicroProfile LRA specification.")
+    @APIResponses({
+            @APIResponse(responseCode = "200", description = "The completion was successful.", content = @Content(schema = @Schema(implementation = String.class)), headers = {
+                    @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "202", description = "The completion is still in progress."
+                    + " The caller should poll the @Status endpoint to determine the outcome.", content = @Content(schema = @Schema(implementation = String.class)), headers = {
+                            @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "409", description = "The completion failed."
+                    + " The caller should use @Forget to release the participant.", content = @Content(schema = @Schema(implementation = String.class))),
+            @APIResponse(responseCode = "410", description = "The participant is no longer aware of this LRA.", content = @Content(schema = @Schema(implementation = String.class))),
+    })
+    public Response completeNestedLRA(
+            @Parameter(name = "NestedLraId", description = "The unique identifier of the nested LRA", required = true) @PathParam("NestedLraId") String nestedLraId,
+            @HeaderParam(HttpHeaders.ACCEPT) @DefaultValue(MediaType.TEXT_PLAIN) String mediaType,
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version,
+            @Context UriInfo uriInfo) {
+
+        try {
+            LRAData lraData = lraService.endLRA(toURI(nestedLraId, uriInfo), false, false, null, null);
+            ParticipantStatus pStatus = mapToParticipantStatus(lraData.getStatus());
+            return buildNestedResponse(pStatus, version, mediaType);
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.GONE).build();
+        }
+    }
+
+    @PUT
+    @Path("{NestedLraId}/compensate")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
+    @Operation(summary = "Compensate a nested LRA", description = "Implements the @Compensate participant contract"
+            + " for a nested LRA as defined by the MicroProfile LRA specification."
+            + " Per the spec, a nested LRA that has already closed can still be asked"
+            + " to compensate if the parent LRA cancels (Closed -> Cancelling LRA transition).")
+    @APIResponses({
+            @APIResponse(responseCode = "200", description = "The compensation was successful.", content = @Content(schema = @Schema(implementation = String.class)), headers = {
+                    @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "202", description = "The compensation is still in progress."
+                    + " The caller should poll the @Status endpoint to determine the outcome.", content = @Content(schema = @Schema(implementation = String.class)), headers = {
+                            @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "409", description = "The compensation failed."
+                    + " The caller should use @Forget to release the participant.", content = @Content(schema = @Schema(implementation = String.class))),
+            @APIResponse(responseCode = "410", description = "The participant is no longer aware of this LRA.", content = @Content(schema = @Schema(implementation = String.class))),
+    })
+    public Response compensateNestedLRA(
+            @Parameter(name = "NestedLraId", description = "The unique identifier of the nested LRA", required = true) @PathParam("NestedLraId") String nestedLraId,
+            @HeaderParam(HttpHeaders.ACCEPT) @DefaultValue(MediaType.TEXT_PLAIN) String mediaType,
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version,
+            @Context UriInfo uriInfo) {
+
+        try {
+            LRAData lraData = lraService.endLRA(toURI(nestedLraId, uriInfo), true, true, null, null);
+            ParticipantStatus pStatus = mapToParticipantStatus(lraData.getStatus());
+            return buildNestedResponse(pStatus, version, mediaType);
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.GONE).build();
+        }
+    }
+
+    @DELETE
+    @Path("{NestedLraId}/forget")
+    @Operation(summary = "Forget a nested LRA participant", description = "Implements the @Forget participant contract"
+            + " as defined by the MicroProfile LRA specification."
+            + " Signals that the participant can clean up any resources associated with the LRA."
+            + " Called after a participant has reported a final status (FailedToComplete or FailedToCompensate).")
+    @APIResponses({
+            @APIResponse(responseCode = "200", description = "The participant has been forgotten successfully."),
+            @APIResponse(responseCode = "410", description = "The participant is no longer aware of this LRA."),
+    })
+    public Response forgetNestedLRA(
+            @PathParam("NestedLraId") String nestedLraId,
+            @Context UriInfo uriInfo) {
+        try {
+            lraService.getTransaction(toURI(nestedLraId, uriInfo));
+        } catch (NotFoundException e) {
+            return Response.status(Response.Status.GONE).build();
+        }
+
+        lraService.remove(toURI(nestedLraId, uriInfo));
+
+        return Response.ok().build();
+    }
+
+    private ParticipantStatus mapToParticipantStatus(LRAStatus lraStatus) {
+        switch (lraStatus) {
+            case Active:
+                return ParticipantStatus.Active;
+            case Closed:
+                return ParticipantStatus.Completed;
+            case Cancelled:
+                return ParticipantStatus.Compensated;
+            case Closing:
+                return ParticipantStatus.Completing;
+            case Cancelling:
+                return ParticipantStatus.Compensating;
+            case FailedToClose:
+                return ParticipantStatus.FailedToComplete;
+            case FailedToCancel:
+                return ParticipantStatus.FailedToCompensate;
+            default:
+                String errMsg = LRALogger.i18nLogger.warn_invalid_lraStatus(String.valueOf(lraStatus));
+                LRALogger.logger.debug(errMsg);
+                throw new WebApplicationException(errMsg, Response.status(INTERNAL_SERVER_ERROR)
+                        .entity(errMsg)
+                        .build());
+        }
+    }
+
+    /**
+     * Build a response following the participant contract:
+     * 200 — terminal success (Completed, Compensated)
+     * 202 — in progress (Completing, Compensating)
+     * 409 — failure (FailedToComplete, FailedToCompensate)
+     */
+    private Response buildNestedResponse(ParticipantStatus pStatus, String apiVersion, String mediaType) {
+        int httpStatus;
+        switch (pStatus) {
+            case Completed:
+            case Compensated:
+                httpStatus = Response.Status.OK.getStatusCode();
+                break;
+            case Completing:
+            case Compensating:
+                httpStatus = Response.Status.ACCEPTED.getStatusCode();
+                break;
+            case FailedToComplete:
+            case FailedToCompensate:
+                httpStatus = Response.Status.CONFLICT.getStatusCode();
+                break;
+            default:
+                httpStatus = Response.Status.OK.getStatusCode();
+                break;
+        }
+
+        String statusName = pStatus.name();
+        Response.ResponseBuilder builder = Response.status(httpStatus)
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, apiVersion);
+
+        if (mediaType.equals(MediaType.APPLICATION_JSON)) {
+            JsonObject model = Json.createObjectBuilder()
+                    .add("status", statusName)
+                    .build();
+            return builder.entity(model.toString()).build();
+        } else {
+            return builder.entity(statusName).build();
+        }
+    }
+
+    private URI toURI(String lraId, UriInfo uriInfo) {
+        URL url;
+        String decodedURL = URLDecoder.decode(lraId, StandardCharsets.UTF_8);
+
+        try {
+            url = new URL(decodedURL);
+            url.toURI();
+        } catch (Exception e) {
+            try {
+                url = new URL(String.format("%s%s/%s", uriInfo.getBaseUri(), COORDINATOR_PATH_NAME, lraId));
+            } catch (MalformedURLException e1) {
+                String errMsg = LRALogger.i18nLogger.error_invalidStringFormatOfUrl(lraId, e1);
+                LRALogger.logger.error(errMsg);
+                throw new WebApplicationException(errMsg, Response.status(BAD_REQUEST)
+                        .entity(errMsg)
+                        .build());
+            }
+        }
+
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            String errMsg = LRALogger.i18nLogger.error_invalidStringFormatOfUrl(lraId, e);
+            LRALogger.logger.warn(errMsg);
+            throw new WebApplicationException(errMsg, Response.status(BAD_REQUEST)
+                    .entity(errMsg)
+                    .build());
+        }
+    }
+}

--- a/coordinator/src/main/java/io/narayana/lra/coordinator/api/NestedCoordinator.java
+++ b/coordinator/src/main/java/io/narayana/lra/coordinator/api/NestedCoordinator.java
@@ -200,29 +200,35 @@ public class NestedCoordinator {
     }
 
     /**
-     * Build a response following the participant contract:
+     * Build a response following the participant contract.
+     * API version 2.0+ returns spec-compliant HTTP status codes:
      * 200 — terminal success (Completed, Compensated)
      * 202 — in progress (Completing, Compensating)
      * 409 — failure (FailedToComplete, FailedToCompensate)
+     * Older versions always return 200 for backward compatibility.
      */
     private Response buildNestedResponse(ParticipantStatus pStatus, String apiVersion, String mediaType) {
         int httpStatus;
-        switch (pStatus) {
-            case Completed:
-            case Compensated:
-                httpStatus = Response.Status.OK.getStatusCode();
-                break;
-            case Completing:
-            case Compensating:
-                httpStatus = Response.Status.ACCEPTED.getStatusCode();
-                break;
-            case FailedToComplete:
-            case FailedToCompensate:
-                httpStatus = Response.Status.CONFLICT.getStatusCode();
-                break;
-            default:
-                httpStatus = Response.Status.OK.getStatusCode();
-                break;
+        if (!supportsParticipantStatusCodes(apiVersion)) {
+            httpStatus = Response.Status.OK.getStatusCode();
+        } else {
+            switch (pStatus) {
+                case Completed:
+                case Compensated:
+                    httpStatus = Response.Status.OK.getStatusCode();
+                    break;
+                case Completing:
+                case Compensating:
+                    httpStatus = Response.Status.ACCEPTED.getStatusCode();
+                    break;
+                case FailedToComplete:
+                case FailedToCompensate:
+                    httpStatus = Response.Status.CONFLICT.getStatusCode();
+                    break;
+                default:
+                    httpStatus = Response.Status.OK.getStatusCode();
+                    break;
+            }
         }
 
         String statusName = pStatus.name();
@@ -267,5 +273,13 @@ public class NestedCoordinator {
                     .entity(errMsg)
                     .build());
         }
+    }
+
+    private static boolean supportsParticipantStatusCodes(String version) {
+        return version != null
+                && !version.equals(LRAConstants.API_VERSION_1_0)
+                && !version.equals(LRAConstants.API_VERSION_1_1)
+                && !version.equals(LRAConstants.API_VERSION_1_2)
+                && !version.equals(LRAConstants.API_VERSION_1_3);
     }
 }

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRAStateModelTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRAStateModelTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.narayana.lra.LRAConstants;
 import io.narayana.lra.client.NarayanaLRAClient;
 import io.narayana.lra.coordinator.api.Coordinator;
 import io.narayana.lra.coordinator.domain.service.LRAService;
@@ -1078,19 +1079,19 @@ public class LRAStateModelTest extends LRATestBase {
     // ===================================================================
 
     /**
-     * @Complete returns 202 with Completing when a participant in the nested LRA
-     *           is unreachable. Per the spec, 202 signals that the completion is still in progress.
+     * With API version 2.0, @Complete returns 202 with Completing when a participant
+     * in the nested LRA is unreachable.
      */
     @Test
-    public void testNestedCompleteReturns202ForCompleting() {
+    public void testNestedCompleteReturns202ForCompletingWithV2() {
         URI parentId = lraClient.startLRA(testName + "-parent");
         URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
 
         enlistUnreachableParticipantInLRA(childId);
 
-        try (Response response = rawNestedComplete(childId)) {
+        try (Response response = rawNestedCompleteWithVersion(childId, LRAConstants.API_VERSION_2_0)) {
             assertEquals(202, response.getStatus(),
-                    "@Complete must return 202 when participants have not all responded");
+                    "@Complete with v2.0 must return 202 when participants have not all responded");
             assertEquals(ParticipantStatus.Completing.name(), response.readEntity(String.class),
                     "@Complete 202 body must be the ParticipantStatus Completing");
         }
@@ -1099,19 +1100,19 @@ public class LRAStateModelTest extends LRATestBase {
     }
 
     /**
-     * @Compensate returns 202 with Compensating when a participant in the nested LRA
-     *             is unreachable. Per the spec, 202 signals that the compensation is still in progress.
+     * With API version 2.0, @Compensate returns 202 with Compensating when a participant
+     * in the nested LRA is unreachable.
      */
     @Test
-    public void testNestedCompensateReturns202ForCompensating() {
+    public void testNestedCompensateReturns202ForCompensatingWithV2() {
         URI parentId = lraClient.startLRA(testName + "-parent");
         URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
 
         enlistUnreachableParticipantInLRA(childId);
 
-        try (Response response = rawNestedCompensate(childId)) {
+        try (Response response = rawNestedCompensateWithVersion(childId, LRAConstants.API_VERSION_2_0)) {
             assertEquals(202, response.getStatus(),
-                    "@Compensate must return 202 when participants have not all responded");
+                    "@Compensate with v2.0 must return 202 when participants have not all responded");
             assertEquals(ParticipantStatus.Compensating.name(), response.readEntity(String.class),
                     "@Compensate 202 body must be the ParticipantStatus Compensating");
         }
@@ -1120,19 +1121,19 @@ public class LRAStateModelTest extends LRATestBase {
     }
 
     /**
-     * @Complete returns 409 with FailedToComplete when a participant in the nested LRA
-     *           reports failure. Per the spec, 409 signals that the participant failed.
+     * With API version 2.0, @Complete returns 409 with FailedToComplete when a participant
+     * in the nested LRA reports failure.
      */
     @Test
-    public void testNestedCompleteReturns409ForFailedToComplete() {
+    public void testNestedCompleteReturns409ForFailedToCompleteWithV2() {
         URI parentId = lraClient.startLRA(testName + "-parent");
         URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
 
         enlistFailingParticipant(childId);
 
-        try (Response response = rawNestedComplete(childId)) {
+        try (Response response = rawNestedCompleteWithVersion(childId, LRAConstants.API_VERSION_2_0)) {
             assertEquals(409, response.getStatus(),
-                    "@Complete must return 409 when a participant failed to complete");
+                    "@Complete with v2.0 must return 409 when a participant failed to complete");
             assertEquals(ParticipantStatus.FailedToComplete.name(), response.readEntity(String.class),
                     "@Complete 409 body must be the ParticipantStatus FailedToComplete");
         }
@@ -1141,21 +1142,61 @@ public class LRAStateModelTest extends LRATestBase {
     }
 
     /**
-     * @Compensate returns 409 with FailedToCompensate when a participant in the nested LRA
-     *             reports failure. Per the spec, 409 signals that the participant failed.
+     * With API version 2.0, @Compensate returns 409 with FailedToCompensate when a participant
+     * in the nested LRA reports failure.
      */
     @Test
-    public void testNestedCompensateReturns409ForFailedToCompensate() {
+    public void testNestedCompensateReturns409ForFailedToCompensateWithV2() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistFailingParticipant(childId);
+
+        try (Response response = rawNestedCompensateWithVersion(childId, LRAConstants.API_VERSION_2_0)) {
+            assertEquals(409, response.getStatus(),
+                    "@Compensate with v2.0 must return 409 when a participant failed to compensate");
+            assertEquals(ParticipantStatus.FailedToCompensate.name(), response.readEntity(String.class),
+                    "@Compensate 409 body must be the ParticipantStatus FailedToCompensate");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * With legacy API versions (pre-2.0), @Complete returns 200 even for non-terminal states.
+     */
+    @Test
+    public void testNestedCompleteReturns200ForLegacyVersion() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistUnreachableParticipantInLRA(childId);
+
+        try (Response response = rawNestedComplete(childId)) {
+            assertEquals(200, response.getStatus(),
+                    "@Complete with default version must return 200 for backward compatibility");
+            assertEquals(ParticipantStatus.Completing.name(), response.readEntity(String.class),
+                    "Body must still contain the ParticipantStatus");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * With legacy API versions (pre-2.0), @Compensate returns 200 even for failed states.
+     */
+    @Test
+    public void testNestedCompensateReturns200ForLegacyVersion() {
         URI parentId = lraClient.startLRA(testName + "-parent");
         URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
 
         enlistFailingParticipant(childId);
 
         try (Response response = rawNestedCompensate(childId)) {
-            assertEquals(409, response.getStatus(),
-                    "@Compensate must return 409 when a participant failed to compensate");
+            assertEquals(200, response.getStatus(),
+                    "@Compensate with default version must return 200 for backward compatibility");
             assertEquals(ParticipantStatus.FailedToCompensate.name(), response.readEntity(String.class),
-                    "@Compensate 409 body must be the ParticipantStatus FailedToCompensate");
+                    "Body must still contain the ParticipantStatus");
         }
 
         lraClient.cancelLRA(parentId);
@@ -1229,9 +1270,23 @@ public class LRAStateModelTest extends LRATestBase {
                 .request().put(Entity.text(""));
     }
 
+    private Response rawNestedCompleteWithVersion(URI childId, String apiVersion) {
+        return client.target(nestedUrl(childId) + "/" + COMPLETE)
+                .request()
+                .header(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME, apiVersion)
+                .put(Entity.text(""));
+    }
+
     private Response rawNestedCompensate(URI childId) {
         return client.target(nestedUrl(childId) + "/" + COMPENSATE)
                 .request().put(Entity.text(""));
+    }
+
+    private Response rawNestedCompensateWithVersion(URI childId, String apiVersion) {
+        return client.target(nestedUrl(childId) + "/" + COMPENSATE)
+                .request()
+                .header(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME, apiVersion)
+                .put(Entity.text(""));
     }
 
     private Response rawNestedStatus(URI childId) {

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRAStateModelTest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRAStateModelTest.java
@@ -5,7 +5,12 @@
 
 package io.narayana.lra.coordinator.domain.model;
 
+import static io.narayana.lra.LRAConstants.COMPENSATE;
+import static io.narayana.lra.LRAConstants.COMPLETE;
 import static io.narayana.lra.LRAConstants.COORDINATOR_PATH_NAME;
+import static io.narayana.lra.LRAConstants.FORGET;
+import static io.narayana.lra.LRAConstants.NESTED_COORDINATOR_PATH_NAME;
+import static io.narayana.lra.LRAConstants.STATUS;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -215,8 +220,8 @@ public class LRAStateModelTest extends LRATestBase {
         String lraUid = lraId.toASCIIString().split("\\?")[0];
         String prefix = TestPortProvider.generateURL("/base/failing-test");
         String linkHeader = String.join(",",
-                makeLink(prefix, "complete"),
-                makeLink(prefix, "compensate"));
+                makeLink(prefix, COMPLETE),
+                makeLink(prefix, COMPENSATE));
 
         try (Response response = client.target(lraUid).request().put(Entity.text(linkHeader))) {
             assertEquals(200, response.getStatus(),
@@ -837,23 +842,22 @@ public class LRAStateModelTest extends LRATestBase {
     }
 
     /**
-     * Validates that a non-existent nested LRA reports Compensated participant
-     * status. A nested LRA that has been removed from the coordinator is treated as
-     * having successfully compensated.
+     * Per the @Status participant contract, a participant that is no longer aware
+     * of an LRA must return 410 (Gone). After forgetting a nested LRA, the status
+     * endpoint should return 410.
      */
     @Test
-    public void testNonExistentNestedLRAReportsCompensated() {
+    public void testForgottenNestedLRAReturns410() {
         URI parentId = lraClient.startLRA(testName + "-parent");
         URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
 
-        // Complete and forget the nested LRA
         lraClient.completeNestedLRA(childId);
         lraClient.forgetNestedLRA(childId);
 
-        // A forgotten/non-existent nested LRA should report Compensated (terminal state)
-        ParticipantStatus status = lraClient.getNestedLRAStatus(childId);
-        assertEquals(ParticipantStatus.Compensated, status,
-                "A non-existent nested LRA must report Compensated per coordinator convention");
+        try (Response response = rawNestedStatus(childId)) {
+            assertEquals(410, response.getStatus(),
+                    "A forgotten nested LRA must return 410 (Gone) per the @Status participant contract");
+        }
 
         lraClient.closeLRA(parentId);
     }
@@ -920,5 +924,323 @@ public class LRAStateModelTest extends LRATestBase {
                 "compensate count should have incremented after recovery retry");
 
         BytemanHelper.removeRendezvous("eventual-compensate-done");
+    }
+
+    // ===================================================================
+    // Nested Endpoint Spec Compliance Tests
+    // ===================================================================
+
+    /**
+     * @Complete returns 200 with Completed when the nested LRA completes successfully.
+     */
+    @Test
+    public void testNestedCompleteReturns200ForCompleted() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        try (Response response = rawNestedComplete(childId)) {
+            assertEquals(200, response.getStatus(),
+                    "@Complete must return 200 for successful completion");
+            assertEquals(ParticipantStatus.Completed.name(), response.readEntity(String.class));
+        }
+
+        lraClient.closeLRA(parentId);
+    }
+
+    /**
+     * @Compensate returns 200 with Compensated when the nested LRA compensates successfully.
+     */
+    @Test
+    public void testNestedCompensateReturns200ForCompensated() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        try (Response response = rawNestedCompensate(childId)) {
+            assertEquals(200, response.getStatus(),
+                    "@Compensate must return 200 for successful compensation");
+            assertEquals(ParticipantStatus.Compensated.name(), response.readEntity(String.class));
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * @Complete returns 410 for a non-existent nested LRA.
+     */
+    @Test
+    public void testNestedCompleteReturns410ForUnknown() {
+        URI fakeChild = URI.create(coordinatorPath + "/unknown-nested-lra?ParentLRA=fake");
+
+        try (Response response = rawNestedComplete(fakeChild)) {
+            assertEquals(410, response.getStatus(),
+                    "@Complete must return 410 for a non-existent nested LRA");
+        }
+    }
+
+    /**
+     * @Compensate returns 410 for a non-existent nested LRA.
+     */
+    @Test
+    public void testNestedCompensateReturns410ForUnknown() {
+        URI fakeChild = URI.create(coordinatorPath + "/unknown-nested-lra?ParentLRA=fake");
+
+        try (Response response = rawNestedCompensate(fakeChild)) {
+            assertEquals(410, response.getStatus(),
+                    "@Compensate must return 410 for a non-existent nested LRA");
+        }
+    }
+
+    /**
+     * @Status returns 200 with the current ParticipantStatus for a known nested LRA.
+     */
+    @Test
+    public void testNestedStatusReturns200ForKnown() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        try (Response response = rawNestedStatus(childId)) {
+            assertEquals(200, response.getStatus(),
+                    "@Status must return 200 for a known nested LRA");
+            assertEquals(ParticipantStatus.Active.name(), response.readEntity(String.class));
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * @Status returns 410 for a non-existent nested LRA.
+     */
+    @Test
+    public void testNestedStatusReturns410ForUnknown() {
+        URI fakeChild = URI.create(coordinatorPath + "/unknown-nested-lra?ParentLRA=fake");
+
+        try (Response response = rawNestedStatus(fakeChild)) {
+            assertEquals(410, response.getStatus(),
+                    "@Status must return 410 for a non-existent nested LRA");
+        }
+    }
+
+    /**
+     * @Forget returns 200 for a known nested LRA.
+     */
+    @Test
+    public void testNestedForgetReturns200ForKnown() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        lraClient.completeNestedLRA(childId);
+
+        try (Response response = rawNestedForget(childId)) {
+            assertEquals(200, response.getStatus(),
+                    "@Forget must return 200 for a known nested LRA");
+        }
+
+        lraClient.closeLRA(parentId);
+    }
+
+    /**
+     * @Forget returns 410 for a non-existent nested LRA.
+     */
+    @Test
+    public void testNestedForgetReturns410ForUnknown() {
+        URI fakeChild = URI.create(coordinatorPath + "/unknown-nested-lra?ParentLRA=fake");
+
+        try (Response response = rawNestedForget(fakeChild)) {
+            assertEquals(410, response.getStatus(),
+                    "@Forget must return 410 for a non-existent nested LRA");
+        }
+    }
+
+    /**
+     * @Forget uses HTTP DELETE per the MicroProfile LRA specification.
+     *         A PUT to the forget endpoint should return 405 (Method Not Allowed).
+     */
+    @Test
+    public void testNestedForgetRequiresDelete() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        lraClient.completeNestedLRA(childId);
+
+        String nestedUrl = nestedUrl(childId);
+        try (Response response = client.target(nestedUrl + "/" + FORGET)
+                .request().put(Entity.text(""))) {
+            assertEquals(405, response.getStatus(),
+                    "@Forget endpoint must reject PUT requests (spec requires DELETE)");
+        }
+
+        lraClient.forgetNestedLRA(childId);
+        lraClient.closeLRA(parentId);
+    }
+
+    // ===================================================================
+    // Nested Endpoint: 202 (in-progress) and 409 (failure) Tests
+    // ===================================================================
+
+    /**
+     * @Complete returns 202 with Completing when a participant in the nested LRA
+     *           is unreachable. Per the spec, 202 signals that the completion is still in progress.
+     */
+    @Test
+    public void testNestedCompleteReturns202ForCompleting() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistUnreachableParticipantInLRA(childId);
+
+        try (Response response = rawNestedComplete(childId)) {
+            assertEquals(202, response.getStatus(),
+                    "@Complete must return 202 when participants have not all responded");
+            assertEquals(ParticipantStatus.Completing.name(), response.readEntity(String.class),
+                    "@Complete 202 body must be the ParticipantStatus Completing");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * @Compensate returns 202 with Compensating when a participant in the nested LRA
+     *             is unreachable. Per the spec, 202 signals that the compensation is still in progress.
+     */
+    @Test
+    public void testNestedCompensateReturns202ForCompensating() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistUnreachableParticipantInLRA(childId);
+
+        try (Response response = rawNestedCompensate(childId)) {
+            assertEquals(202, response.getStatus(),
+                    "@Compensate must return 202 when participants have not all responded");
+            assertEquals(ParticipantStatus.Compensating.name(), response.readEntity(String.class),
+                    "@Compensate 202 body must be the ParticipantStatus Compensating");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * @Complete returns 409 with FailedToComplete when a participant in the nested LRA
+     *           reports failure. Per the spec, 409 signals that the participant failed.
+     */
+    @Test
+    public void testNestedCompleteReturns409ForFailedToComplete() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistFailingParticipant(childId);
+
+        try (Response response = rawNestedComplete(childId)) {
+            assertEquals(409, response.getStatus(),
+                    "@Complete must return 409 when a participant failed to complete");
+            assertEquals(ParticipantStatus.FailedToComplete.name(), response.readEntity(String.class),
+                    "@Complete 409 body must be the ParticipantStatus FailedToComplete");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    /**
+     * @Compensate returns 409 with FailedToCompensate when a participant in the nested LRA
+     *             reports failure. Per the spec, 409 signals that the participant failed.
+     */
+    @Test
+    public void testNestedCompensateReturns409ForFailedToCompensate() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        enlistFailingParticipant(childId);
+
+        try (Response response = rawNestedCompensate(childId)) {
+            assertEquals(409, response.getStatus(),
+                    "@Compensate must return 409 when a participant failed to compensate");
+            assertEquals(ParticipantStatus.FailedToCompensate.name(), response.readEntity(String.class),
+                    "@Compensate 409 body must be the ParticipantStatus FailedToCompensate");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    // ===================================================================
+    // Nested @Status: verify body for each LRA state
+    // ===================================================================
+
+    /**
+     * @Status returns Completed after a successful completion.
+     */
+    @Test
+    public void testNestedStatusReturnsCompletedAfterComplete() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        rawNestedComplete(childId).close();
+
+        try (Response response = rawNestedStatus(childId)) {
+            assertEquals(200, response.getStatus());
+            assertEquals("Completed", response.readEntity(String.class),
+                    "@Status must return Completed after successful completion");
+        }
+
+        lraClient.closeLRA(parentId);
+    }
+
+    /**
+     * After successful compensation, the coordinator removes the nested LRA (terminal state).
+     *
+     * @Status must return 410 since the participant is no longer aware of the LRA.
+     */
+    @Test
+    public void testNestedStatusReturns410AfterCompensate() {
+        URI parentId = lraClient.startLRA(testName + "-parent");
+        URI childId = lraClient.startLRA(parentId, testName + "-child", 0L, ChronoUnit.SECONDS);
+
+        rawNestedCompensate(childId).close();
+
+        try (Response response = rawNestedStatus(childId)) {
+            assertEquals(410, response.getStatus(),
+                    "@Status must return 410 after the nested LRA has been compensated and cleaned up");
+        }
+
+        lraClient.cancelLRA(parentId);
+    }
+
+    private void enlistUnreachableParticipantInLRA(URI lraId) {
+        String lraUrl = lraId.toASCIIString().split("\\?")[0];
+        String prefix = "http://localhost:39999/unreachable";
+        String linkHeader = String.join(",",
+                makeLink(prefix, COMPLETE),
+                makeLink(prefix, COMPENSATE));
+
+        try (Response response = client.target(lraUrl).request().put(Entity.text(linkHeader))) {
+            assertEquals(200, response.getStatus(),
+                    "Unexpected status enlisting unreachable participant: " + response.readEntity(String.class));
+        }
+    }
+
+    // --- Raw HTTP helpers for nested endpoints ---
+
+    private String nestedUrl(URI childId) {
+        String encoded = java.net.URLEncoder.encode(childId.toASCIIString(), java.nio.charset.StandardCharsets.UTF_8);
+        return coordinatorPath + "/" + NESTED_COORDINATOR_PATH_NAME + "/" + encoded;
+    }
+
+    private Response rawNestedComplete(URI childId) {
+        return client.target(nestedUrl(childId) + "/" + COMPLETE)
+                .request().put(Entity.text(""));
+    }
+
+    private Response rawNestedCompensate(URI childId) {
+        return client.target(nestedUrl(childId) + "/" + COMPENSATE)
+                .request().put(Entity.text(""));
+    }
+
+    private Response rawNestedStatus(URI childId) {
+        return client.target(nestedUrl(childId) + "/" + STATUS)
+                .request().get();
+    }
+
+    private Response rawNestedForget(URI childId) {
+        return client.target(nestedUrl(childId) + "/" + FORGET)
+                .request().delete();
     }
 }

--- a/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -1762,15 +1762,12 @@ public class LRATest extends LRATestBase {
             // Now forget the nested LRA - this should succeed without throwing an exception
             lraClient.forgetNestedLRA(childId);
 
-            // Verify that the nested LRA is truly forgotten by checking its status
-            // It should either not be found or report as compensated (cleanup state)
+            // After forget, the @Status endpoint must return 410 (Gone)
             try {
-                ParticipantStatus afterForget = lraClient.getNestedLRAStatus(childId);
-                // If we get here, the LRA still exists but should be in a terminal state
-                assertTrue(afterForget == ParticipantStatus.Compensated || afterForget == ParticipantStatus.Completed,
-                        "After forget, nested LRA should be in terminal state if still exists");
+                lraClient.getNestedLRAStatus(childId);
+                fail("Expected NotFoundException for a forgotten nested LRA");
             } catch (NotFoundException expected) {
-                // This is expected - the LRA has been forgotten and removed
+                // per the @Status participant contract, 410 (Gone) for forgotten LRAs
             }
         } finally {
             // Clean up - close parent

--- a/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -15,6 +15,7 @@ public final class LRAConstants {
     // warning: the WildFly subsystem uses lra-coordinator/lra-coordinator
     public static final String COORDINATOR_PATH_NAME = "lra-coordinator";
     public static final String RECOVERY_COORDINATOR_PATH_NAME = "recovery";
+    public static final String NESTED_COORDINATOR_PATH_NAME = "nested";
 
     public static final String COMPLETE = "complete";
     public static final String COMPENSATE = "compensate";

--- a/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -36,6 +36,7 @@ public final class LRAConstants {
     public static final String API_VERSION_1_0 = "1.0";
     public static final String API_VERSION_1_1 = "1.1";
     public static final String API_VERSION_1_2 = "1.2";
+    public static final String API_VERSION_1_3 = "1.3";
     public static final String API_VERSION_2_0 = "2.0";
 
     /*
@@ -43,12 +44,26 @@ public final class LRAConstants {
      * Any version not mentioned in the list of the supported versions is unsupported
      * and will fail on incoming HTTP call.
      * The valid version format is specified in API.adoc document.
-     * When a new version with a new features is added consider adding API tests under 'test/basic'.
+     * When a new version with new features is added consider adding API tests under 'test/basic'.
+     *
+     * Version history:
+     * 1.0 - initial version
+     * 1.1 - participant data support
+     * 1.2 - participant link header support
+     * 1.3 - nested LRA endpoints extracted into NestedCoordinator sub-resource;
+     * nested status returns 200/410 per @Status;
+     * nested forget uses HTTP DELETE per @Forget and returns 200/410
+     * 2.0 - close/cancel return 202 for transitional states (Closing/Cancelling)
+     * and 503 for transient failures (lock contention/store failure);
+     * nested complete/compensate return 200/202/409 per @Complete/@Compensate
+     * (pre-2.0 always returns 200 for backward compatibility);
+     * opt-in only, planned as default for a future release
      */
     public static final String[] NARAYANA_LRA_API_SUPPORTED_VERSIONS = new String[] {
             API_VERSION_1_0,
             API_VERSION_1_1,
             API_VERSION_1_2,
+            API_VERSION_1_3,
             API_VERSION_2_0
     };
 
@@ -56,7 +71,7 @@ public final class LRAConstants {
      * The Narayana API version for LRA coordinator supported for the release.
      * Any higher version is considered as unimplemented and unknown.
      */
-    public static final String CURRENT_API_VERSION_STRING = API_VERSION_1_2;
+    public static final String CURRENT_API_VERSION_STRING = API_VERSION_1_3;
 
     public static final String NARAYANA_LRA_API_VERSION_HEADER_NAME = "Narayana-LRA-API-version";
 


### PR DESCRIPTION
addresses issue #325 

Additionally it aligns the participant methods to the spec:
- the JAX-RS method of the /forget endpoint from `@PUT` to `@DELETE`
- /forget should return 410 for unavailable LRAs : aligning tests and client 
- /status should return 410 for unavailable LRAs (not 'compensated' or 'PRECONDITION_FAILED'): aligning tests and client 