### PR TITLE
Improve usability and documentation on running the lra-coordinator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,111 @@ To apply code formatting (enabled by default via the `format` profile):
 | Integration tests — see link:test/README.adoc[test/README.adoc] for details
 |===
 
+== Running the Coordinator
+
+The coordinator URL path differs by runtime:
+
+[cols="1,2"]
+|===
+| Runtime | Coordinator URL
+
+| WildFly WAR or subsystem
+| `http://localhost:8080/lra-coordinator/lra-coordinator`
+
+| Container (Quarkus)
+| `http://localhost:8080/lra-coordinator`
+|===
+
+=== WildFly — coordinator WAR
+
+The simplest way to run the coordinator built from this branch. Build first, then deploy the WAR to any WildFly instance:
+
+[source,sh]
+----
+./mvnw clean install -DskipTests
+
+export JBOSS_HOME=/path/to/wildfly
+$JBOSS_HOME/bin/standalone.sh -c standalone.xml &
+$JBOSS_HOME/bin/jboss-cli.sh -c \
+  "deploy --force coordinator-war/target/lra-coordinator.war"
+----
+
+=== WildFly — built-in subsystem coordinator
+
+The `download` profile downloads WildFly, replaces all LRA module jars with the locally built SNAPSHOTs, and configures the LRA coordinator subsystem — all in one step:
+
+[source,sh]
+----
+./mvnw clean install -DskipTests
+
+mvn process-test-classes -Pdownload -f test/pom.xml -N
+
+export JBOSS_HOME=target/wildfly/wildfly-$(mvn help:evaluate \
+  -Dexpression=version.wildfly -q -DforceStdout -f test/pom.xml)
+$JBOSS_HOME/bin/standalone.sh -c standalone-microprofile.xml
+----
+
+=== Container (quay.io)
+
+Pre-built images are published at https://quay.io/repository/jbosstm/lra-coordinator[quay.io/jbosstm/lra-coordinator].
+Tags follow the pattern `<narayana-version>-<quarkus-version>`. Use `latest` for the most recent release.
+
+[source,sh]
+----
+# Preferred — full network access so the coordinator can reach participant services
+podman run --network host quay.io/jbosstm/lra-coordinator:latest
+
+# Or with explicit port forwarding (limits outbound connectivity)
+podman run -p 8080:8080 quay.io/jbosstm/lra-coordinator:latest
+----
+
+The coordinator is then available at `http://localhost:8080/lra-coordinator`.
+
+=== Quarkus participant — connecting to the coordinator
+
+The `quarkus-narayana-lra` extension makes a Quarkus service an LRA _participant_. It does not run a coordinator itself — add it to your participant application and point it at whichever coordinator is running:
+
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-narayana-lra</artifactId>
+</dependency>
+----
+
+[source,properties]
+----
+# application.properties — adjust the URL to match the coordinator runtime
+# WildFly:            http://coordinator-host:8080/lra-coordinator/lra-coordinator
+# Quarkus/container:  http://coordinator-host:8080/lra-coordinator
+quarkus.lra.coordinator-url=http://localhost:8080/lra-coordinator
+----
+
+**Using SNAPSHOT Narayana artifacts**
+
+`quarkus-narayana-lra` bundles its own `narayana-lra` version. To replace it with the SNAPSHOT from this repo, exclude the bundled jar and declare the local one:
+
+[source,xml]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-narayana-lra</artifactId>
+  <exclusions>
+    <exclusion>
+      <groupId>org.jboss.narayana.lra</groupId>
+      <artifactId>narayana-lra</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+<dependency>
+  <groupId>org.jboss.narayana.lra</groupId>
+  <artifactId>narayana-lra</artifactId>
+  <version>${project.version}</version>
+</dependency>
+----
+
+Requires `./mvnw clean install -DskipTests` first so the SNAPSHOT is in the local Maven repository.
+
 == Running Integration Tests
 
 Integration tests use the link:https://maven.apache.org/surefire/maven-failsafe-plugin/[Maven Failsafe Plugin] and link:https://arquillian.org[Arquillian] to spin up separate JVMs for the coordinator, participant, and test client.

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
     <version.junit>6.1.0</version.junit>
     <version.maven.antrun-plugin>3.2.0</version.maven.antrun-plugin>
     <version.maven.checkstyle-plugin>3.6.0</version.maven.checkstyle-plugin>
+    <version.maven.dependency-plugin>3.11.0</version.maven.dependency-plugin>
     <version.maven.jandex-plugin>3.6.0</version.maven.jandex-plugin>
     <version.maven.jar-plugin>3.5.0</version.maven.jar-plugin>
     <version.maven.shade-plugin>3.2.4</version.maven.shade-plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -213,29 +213,6 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <id>replace-lra-jars</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target xmlns:if="ant:if" xmlns:unless="ant:unless">
-                    <echo if:true="${wildfly.download}">wildfly.download=true, updating LRA jar versions in ${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml</echo>
-                    <echo unless:true="${wildfly.download}">wildfly.download is not true, skipping LRA module.xml update</echo>
-
-                    <!-- Update lra-client-* -->
-                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(lra-client-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
-
-                    <!-- Update lra-proxy-api-* -->
-                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(lra-proxy-api-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
-
-                    <!-- Update narayana-lra-* -->
-                    <replaceregexp byline="true" file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="(narayana-lra-)[^&quot;]+(\.jar)" replace="\1${project.version}\2" if:true="${wildfly.download}"></replaceregexp>
-                  </target>
-                </configuration>
-              </execution>
-
-              <execution>
                 <goals>
                   <goal>run</goal>
                 </goals>
@@ -457,7 +434,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.11.0</version>
+            <version>${version.maven.dependency-plugin}</version>
             <executions>
               <execution>
                 <id>unpack-wildfly</id>
@@ -519,7 +496,73 @@
                       <destFileName>lra-proxy-api-${project.version}.jar</destFileName>
                     </artifactItem>
 
+                    <artifactItem>
+                      <groupId>org.jboss.narayana.lra</groupId>
+                      <artifactId>lra-coordinator-jar</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-coordinator/main</outputDirectory>
+                      <destFileName>lra-coordinator-jar-${project.version}.jar</destFileName>
+                    </artifactItem>
+
+                    <artifactItem>
+                      <groupId>org.jboss.narayana.lra</groupId>
+                      <artifactId>lra-service-base</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-service-base/main</outputDirectory>
+                      <destFileName>lra-service-base-${project.version}.jar</destFileName>
+                    </artifactItem>
+
                   </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>${version.wildfly-maven-plugin}</version>
+            <executions>
+              <execution>
+                <id>configure-lra-coordinator-subsystem</id>
+                <goals>
+                  <goal>execute-commands</goal>
+                </goals>
+                <phase>process-test-classes</phase>
+                <configuration>
+                  <skip>${narayana.noupdate}</skip>
+                  <jbossHome>${wildfly.home}</jbossHome>
+                  <offline>true</offline>
+                  <scripts>
+                    <script>${project.basedir}/src/test/resources/configure-lra-coordinator.cli</script>
+                  </scripts>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>update-coordinator-module-xml</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <phase>process-test-classes</phase>
+                <configuration>
+                  <skip>${narayana.noupdate}</skip>
+                  <target>
+                    <replaceregexp file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-coordinator/main/module.xml" match="lra-coordinator-jar-[^&quot;']+" replace="lra-coordinator-jar-${project.version}.jar"></replaceregexp>
+                    <replaceregexp file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-service-base/main/module.xml" match="lra-service-base-[^&quot;']+" replace="lra-service-base-${project.version}.jar"></replaceregexp>
+                    <replaceregexp file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="lra-client-[^&quot;']+" replace="lra-client-${project.version}.jar"></replaceregexp>
+                    <replaceregexp file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="lra-proxy-api-[^&quot;']+" replace="lra-proxy-api-${project.version}.jar"></replaceregexp>
+                    <replaceregexp file="${wildfly.home}/modules/system/layers/base/org/jboss/narayana/lra/lra-participant/main/module.xml" match="narayana-lra-[^&quot;']+" replace="narayana-lra-${project.version}.jar"></replaceregexp>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/test/src/test/resources/configure-lra-coordinator.cli
+++ b/test/src/test/resources/configure-lra-coordinator.cli
@@ -1,0 +1,26 @@
+## WildFly CLI script to add the LRA coordinator and participant subsystems
+## to standalone-microprofile.xml.
+##
+## Run via: jboss-cli.sh --file=configure-lra-coordinator.cli
+## Uses embed-server so no running WildFly instance is required.
+## Idempotent: each block is skipped if the component already exists.
+
+embed-server --server-config=standalone-microprofile.xml --std-out=discard
+
+if (outcome != success) of /extension=org.wildfly.extension.microprofile.lra-coordinator:read-resource()
+    /extension=org.wildfly.extension.microprofile.lra-coordinator:add()
+end-if
+
+if (outcome != success) of /subsystem=microprofile-lra-coordinator:read-resource()
+    /subsystem=microprofile-lra-coordinator:add()
+end-if
+
+if (outcome != success) of /extension=org.wildfly.extension.microprofile.lra-participant:read-resource()
+    /extension=org.wildfly.extension.microprofile.lra-participant:add()
+end-if
+
+if (outcome != success) of /subsystem=microprofile-lra-participant:read-resource()
+    /subsystem=microprofile-lra-participant:add()
+end-if
+
+stop-embedded-server


### PR DESCRIPTION
Improve usability and documentation on running the lra-coordinator

Only lra-participant artifacts were replaced in the wildfly modules when using the download profile. I have added the lra-coordinator artifacts too.