### PR TITLE
Bump version.io.smallrye.smallrye-config from 3.17.2 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
     <version.io.netty>4.2.16.Final</version.io.netty>
 
-    <version.io.smallrye.smallrye-config>3.17.2</version.io.smallrye.smallrye-config>
+    <version.io.smallrye.smallrye-config>3.18.0</version.io.smallrye.smallrye-config>
     <version.io.smallrye.smallrye-stork>3.0.0</version.io.smallrye.smallrye-stork>
     <version.jakarta.concurrent>3.1.1</version.jakarta.concurrent>
     <version.jakarta.enterprise>4.1.0</version.jakarta.enterprise>

--- a/test/quarkus/context/build/pom.xml
+++ b/test/quarkus/context/build/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>lra-proxy-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-common</artifactId>
+      <version>${version.io.smallrye.smallrye-config}</version>
+    </dependency>
 
     <!-- Use RESTEasy Classic instead of Quarkus REST -->
     <dependency>

--- a/test/quarkus/pom.xml
+++ b/test/quarkus/pom.xml
@@ -23,6 +23,8 @@
   </modules>
 
   <properties>
+    <!-- keep smallrye-config version aligned with the quarkus bom -->
+    <version.io.smallrye.smallrye-config>3.17.2</version.io.smallrye.smallrye-config>
     <version.quarkus>3.37.2</version.quarkus>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Updates `io.smallrye.config:smallrye-config` from 3.17.2 to 3.18.0
- [Release notes](https://github.com/smallrye/smallrye-config/releases)
- [Commits](https://github.com/smallrye/smallrye-config/compare/3.17.2...3.18.0)

Updates `io.smallrye.config:smallrye-config-core` from 3.17.2 to 3.18.0


Override the version.io.smallrye.smallrye-config property in the Quarkus parent POM so the Quarkus subtree stays on the version compatible with Quarkus 3.37.2 while the root BOM upgrades to 3.18.0.