### PR TITLE
jackson-databind upgrade to 2.18.9 (compatible with resteasy)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.10.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.com.h2database>2.4.240</version.com.h2database>
     <version.doxia>1.11.1</version.doxia>
+    <version.fasterxml.jackson.core>2.18.9</version.fasterxml.jackson.core>
     <version.formatter.plugin>2.29.0</version.formatter.plugin>
 
     <version.hamcrest>3.0</version.hamcrest>
@@ -274,6 +275,11 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jackson2-provider</artifactId>
         <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.fasterxml.jackson.core}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
[RESTEasy Jackson 2 Provider](https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-jackson2-provider) latest release uses an older version of jackson-databind, so while waiting for a resteasy release we update to a jackson-databind version  compatible and without vulnerabilities. see https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind