### PR TITLE
Revert "bump com.fasterxml.jackson.core:jackson-databind from 2.18.9 to 2.20.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.10.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.com.h2database>2.4.240</version.com.h2database>
     <version.doxia>1.11.1</version.doxia>
-    <version.fasterxml.jackson.core>2.20.2</version.fasterxml.jackson.core>
+    <version.fasterxml.jackson.core>2.18.9</version.fasterxml.jackson.core>
     <version.formatter.plugin>2.29.0</version.formatter.plugin>
 
     <version.hamcrest>3.0</version.hamcrest>


### PR DESCRIPTION
Reverts jbosstm/lra#395 which was merged by the dependabot but was not needed.

I don't think 2.20.x dependency will be maintained (last release was in January). Instead 2.18.x is still maintained (last release in July).
I specified to the dependabot I don't want it to create new PRs for jackson-databind. I will wait the new release of resteasy and then we can activate again the dependabot for this dependency which will hopefully be at version 2.22.x