### PR TITLE
Revert "Bump com.fasterxml.jackson.core:jackson-databind from 2.18.9 to 2.20.2"

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -53,7 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.check_exclusion.outputs.excluded == 'false' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        if: steps.check_exclusion.outputs.excluded == 'false' && (steps.metadata.outputs.update-type == 'version-update:semver-patch')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.10.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.com.h2database>2.4.240</version.com.h2database>
     <version.doxia>1.11.1</version.doxia>
-    <version.fasterxml.jackson.core>2.20.2</version.fasterxml.jackson.core>
+    <version.fasterxml.jackson.core>2.18.9</version.fasterxml.jackson.core>
     <version.formatter.plugin>2.29.0</version.formatter.plugin>
 
     <version.hamcrest>3.0</version.hamcrest>


### PR DESCRIPTION
Reverts jbosstm/lra#399

I don't think 2.20.x dependency will be maintained (last release was in January). Instead 2.18.x is still maintained (last release in July).
I specified to the dependabot I don't want it to create new PRs for jackson-databind. I will wait the new release of resteasy and then we can activate again the dependabot for this dependency which will hopefully be at version 2.22.x


Disables auto-merge for micros to avoid this scenario in the future: we need to stick to an older minor for resteasy compatibility, that minor is still maintained but some of next minors are not maintained and we don't want dependabot to bump to those versions, so better to enforce a human review.

An alternative might be to exclude the jackson-databind from the upgradable dependencies: https://github.com/jbosstm/lra/blob/main/.github/workflows/dependabot-auto-merge.yml#L17-L21
However I don't think this is appropriate for jackson-databind as this is a workaround until next resteasy release updates jackson-databind itself.
